### PR TITLE
Travis-CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+# NOTE(bja, 2017-11) travis-ci dosen't support python language builds
+#  on mac os. As a work around, we declare as a 'generic', use built-in
+#  python on linux, and manually install python with homebrew on osx.
+
+language: generic
+matrix:
+  include:
+  - os: linux
+    language: python
+    python: 2.7
+  - os: osx
+    language: generic
+    before_install:
+      # NOTE(bja, 2017-11) update is slow, 2.7.12 installed by default, good enough!
+      # - brew update
+      # - brew outdated python2 || brew upgrade python2
+      - virtualenv env -p python2
+      - source env/bin/activate
+install:
+  - pip install -r test/requirements.txt
+script:
+  - cd test; make test
+#  - cd test; make lint
+  

--- a/README
+++ b/README
@@ -1,5 +1,7 @@
 -- AUTOMATICALLY GENERATED FILE. DO NOT EDIT --
 
+[![Build Status](https://travis-ci.org/NCAR/manage_externals.svg?branch=master)](https://travis-ci.org/NCAR/manage_externals)
+
 usage: checkout_externals.py [-h] [-m [MODEL]] [-o] [-S] [-v] [--backtrace]
                              [-d]
 

--- a/README
+++ b/README
@@ -1,25 +1,25 @@
 -- AUTOMATICALLY GENERATED FILE. DO NOT EDIT --
 
-usage: checkout_externals.py [-h] [-m [MODEL]] [-o] [-s] [-v] [--backtrace]
+usage: checkout_externals.py [-h] [-m [MODEL]] [-o] [-S] [-v] [--backtrace]
                              [-d]
 
 checkout_externals.py manages checking out CESM externals from revision control
-based on a model description file. By default only the required
+based on a externals description file. By default only the required
 components of the model are checkout out.
 
 NOTE: checkout_externals.py *MUST* be run from the root of the source tree.
 
 Running checkout_externals.py without the '--status' option will always attempt to
-synchronize the working copy with the model description.
+synchronize the working copy with the externals description.
 
 optional arguments:
   -h, --help            show this help message and exit
   -m [MODEL], --model [MODEL]
-                        The model description filename. Default: CESM.xml.
+                        The externals description filename. Default: CESM.cfg.
   -o, --optional        By default only the required model components are
                         checked out. This flag will also checkout the optional
                         componets of the model.
-  -s, --status          Output status of the repositories managed by
+  -S, --status          Output status of the repositories managed by
                         checkout_externals.py. By default only summary
                         information is provided. Use verbose output to see
                         details.
@@ -52,7 +52,7 @@ The root of the source tree will be referred to as ${SRC_ROOT} below.
       $ ./checkout_cesm/checkout_externals.py
 
   * To update all required components to the current values in the
-    model description file, re-run checkout_externals.py:
+    externals description file, re-run checkout_externals.py:
 
       $ cd ${SRC_ROOT}
       $ ./checkout_cesm/checkout_externals.py
@@ -83,12 +83,12 @@ The root of the source tree will be referred to as ${SRC_ROOT} below.
 
     where:
       * column one indicates the status of the repository in relation
-        to the model description file.
+        to the externals description file.
       * column two indicates whether the working copy has modified files.
       * column three shows how the repository is managed, optional or required
 
     Colunm one will be one of these values:
-      * m : modified : repository is modefied compared to the model description
+      * m : modified : repository is modefied compared to the externals description
       * e : empty : directory does not exist - checkout_externals.py has not been run
       * ? : unknown : directory exists but .git or .svn directories are missing
 
@@ -108,7 +108,7 @@ The root of the source tree will be referred to as ${SRC_ROOT} below.
 
 # Model description file:
 
-  The model description contains a list of the model components that
+  The externals description contains a list of the model components that
   are used and their version control locations. Each component has:
 
   * name (string) : component name, e.g. cime, cism, clm, cam, etc.
@@ -138,7 +138,7 @@ The root of the source tree will be referred to as ${SRC_ROOT} below.
 
   * externals (string) : relative path to the external model
     description file that should also be used. It is *relative* to the
-    component local_path. For example, the CESM model description will
+    component local_path. For example, the CESM externals description will
     load clm. CLM has additional externals that must be downloaded to
     be complete. Those additional externals are managed from the clm
     source root by the file pointed to by 'externals'.

--- a/test/Makefile
+++ b/test/Makefile
@@ -38,6 +38,7 @@ test : utest
 
 readme : FORCE
 	echo '-- AUTOMATICALLY GENERATED FILE. DO NOT EDIT --\n' > ../README
+	echo '[![Build Status](https://travis-ci.org/NCAR/manage_externals.svg?branch=master)](https://travis-ci.org/NCAR/manage_externals)\n' >> ../README
 	$(EXE) --help >> ../README
 
 style : FORCE
@@ -55,10 +56,7 @@ py3 :
 
 env : FORCE
 	$(PYPATH) virtualenv --python $(PYTHON) $@_$(PYTHON)
-	. $@_$(PYTHON)/bin/activate; pip install 'pyaml>=17.10.0'
-	. $@_$(PYTHON)/bin/activate; pip install 'pylint>=1.7.0'
-	. $@_$(PYTHON)/bin/activate; pip install 'autopep8>=1.3.0'
-	. $@_$(PYTHON)/bin/activate; pip install 'coverage>=4.4.0'
+	. $@_$(PYTHON)/bin/activate; pip install -r requirements.txt
 
 clean : FORCE
 	-rm -rf *~ *.pyc

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,0 +1,4 @@
+pyaml>=17.10.0
+pylint>=1.7.0
+autopep8>=1.3.0
+coverage>=4.4.0


### PR DESCRIPTION
Integrate Travis-CI builds.

Add travis-ci configuration file. Add build status badge to autogenerated readme file.