### PR TITLE
Convert readme file to markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Build Status](https://travis-ci.org/NCAR/manage_externals.svg?branch=master)](https://travis-ci.org/NCAR/manage_externals)
 
+```
+
 usage: checkout_externals.py [-h] [-m [MODEL]] [-o] [-S] [-v] [--backtrace]
                              [-d]
 
@@ -32,32 +34,36 @@ optional arguments:
   -d, --debug           DEVELOPER: output additional debugging information to
                         the screen and log file.
 
+```
 NOTE: checkout_externals.py *MUST* be run from the root of the source tree it
 is managing. For example, if you cloned CLM with:
 
     $ git clone git@github.com/ncar/clm clm-dev
 
 Then the root of the source tree is /path/to/clm-dev. If you obtained
-CLM via an svn checkout of CESM and you need to checkout the CLM
-externals, then the root of the source tree for CLM is:
+CLM via a checkout of CESM:
 
-    /path/to/cesm-dev/components/clm
+    $ git clone git@github.com/escomp/cesm cesm-dev
 
-The root of the source tree will be referred to as ${SRC_ROOT} below.
+and you need to checkout the CLM externals, then the root of the
+source tree is /path/to/cesm-dev. Do *NOT* run checkout_externals.py
+from within /path/to/cesm-dev/components/clm.
 
-# Supported workflows:
+The root of the source tree will be referred to as `${SRC_ROOT}` below.
+
+# Supported workflows
 
   * Checkout all required components from the default model
     description file:
 
-      $ cd ${SRC_ROOT}
-      $ ./checkout_cesm/checkout_externals.py
+        $ cd ${SRC_ROOT}
+        $ ./manage_externals/checkout_externals.py
 
   * To update all required components to the current values in the
     externals description file, re-run checkout_externals.py:
 
-      $ cd ${SRC_ROOT}
-      $ ./checkout_cesm/checkout_externals.py
+        $ cd ${SRC_ROOT}
+        $ ./manage_externals/checkout_externals.py
 
     If there are *any* modifications to *any* working copy according
     to the git or svn 'status' command, checkout_externals.py
@@ -68,20 +74,20 @@ The root of the source tree will be referred to as ${SRC_ROOT} below.
   * Checkout all required components from a user specified model
     description file:
 
-      $ cd ${SRC_ROOT}
-      $ ./checkout_cesm/checkout_externals.py --model myCESM.xml
+        $ cd ${SRC_ROOT}
+        $ ./manage_externals/checkout_externals.py --model myCESM.xml
 
   * Status summary of the repositories managed by checkout_externals.py:
 
-      $ cd ${SRC_ROOT}
-      $ ./checkout_cesm/checkout_externals.py --status
+        $ cd ${SRC_ROOT}
+        $ ./manage_externals/checkout_externals.py --status
 
-      m   components/cism
-       M  src/fates
-      e-o components/mosart
-          cime
-          components/rtm
-      e-o tools/PTCLM
+              ./cime
+          m   ./components/cism
+              ./components/mosart
+          e-o ./components/rtm
+           M  ./src/fates
+          e-o ./tools/PTCLM
 
     where:
       * column one indicates the status of the repository in relation
@@ -105,10 +111,10 @@ The root of the source tree will be referred to as ${SRC_ROOT} below.
 
   * Detailed git or svn status of the repositories managed by checkout_externals.py:
 
-      $ cd ${SRC_ROOT}
-      $ ./checkout_cesm/checkout_externals.py --status --verbose
+        $ cd ${SRC_ROOT}
+        $ ./manage_externals/checkout_externals.py --status --verbose
 
-# Model description file:
+# Model description file
 
   The externals description contains a list of the model components that
   are used and their version control locations. Each component has:

--- a/checkout_externals.py
+++ b/checkout_externals.py
@@ -52,33 +52,37 @@ synchronize the working copy with the externals description.
 '''
 
     epilog = '''
+```
 NOTE: %(prog)s *MUST* be run from the root of the source tree it
 is managing. For example, if you cloned CLM with:
 
     $ git clone git@github.com/ncar/clm clm-dev
 
 Then the root of the source tree is /path/to/clm-dev. If you obtained
-CLM via an svn checkout of CESM and you need to checkout the CLM
-externals, then the root of the source tree for CLM is:
+CLM via a checkout of CESM:
 
-    /path/to/cesm-dev/components/clm
+    $ git clone git@github.com/escomp/cesm cesm-dev
 
-The root of the source tree will be referred to as ${SRC_ROOT} below.
+and you need to checkout the CLM externals, then the root of the
+source tree is /path/to/cesm-dev. Do *NOT* run %(prog)s
+from within /path/to/cesm-dev/components/clm.
+
+The root of the source tree will be referred to as `${SRC_ROOT}` below.
 
 
-# Supported workflows:
+# Supported workflows
 
   * Checkout all required components from the default model
     description file:
 
-      $ cd ${SRC_ROOT}
-      $ ./checkout_cesm/%(prog)s
+        $ cd ${SRC_ROOT}
+        $ ./manage_externals/%(prog)s
 
   * To update all required components to the current values in the
     externals description file, re-run %(prog)s:
 
-      $ cd ${SRC_ROOT}
-      $ ./checkout_cesm/%(prog)s
+        $ cd ${SRC_ROOT}
+        $ ./manage_externals/%(prog)s
 
     If there are *any* modifications to *any* working copy according
     to the git or svn 'status' command, %(prog)s
@@ -89,20 +93,21 @@ The root of the source tree will be referred to as ${SRC_ROOT} below.
   * Checkout all required components from a user specified model
     description file:
 
-      $ cd ${SRC_ROOT}
-      $ ./checkout_cesm/%(prog)s --model myCESM.xml
+        $ cd ${SRC_ROOT}
+        $ ./manage_externals/%(prog)s --model myCESM.xml
 
   * Status summary of the repositories managed by %(prog)s:
 
-      $ cd ${SRC_ROOT}
-      $ ./checkout_cesm/%(prog)s --status
+        $ cd ${SRC_ROOT}
+        $ ./manage_externals/%(prog)s --status
 
-      m   components/cism
-       M  src/fates
-      e-o components/mosart
-          cime
-          components/rtm
-      e-o tools/PTCLM
+              ./cime
+          m   ./components/cism
+              ./components/mosart
+          e-o ./components/rtm
+           M  ./src/fates
+          e-o ./tools/PTCLM
+
 
     where:
       * column one indicates the status of the repository in relation
@@ -126,10 +131,10 @@ The root of the source tree will be referred to as ${SRC_ROOT} below.
 
   * Detailed git or svn status of the repositories managed by %(prog)s:
 
-      $ cd ${SRC_ROOT}
-      $ ./checkout_cesm/%(prog)s --status --verbose
+        $ cd ${SRC_ROOT}
+        $ ./manage_externals/%(prog)s --status --verbose
 
-# Model description file:
+# Model description file
 
   The externals description contains a list of the model components that
   are used and their version control locations. Each component has:

--- a/test/Makefile
+++ b/test/Makefile
@@ -24,9 +24,11 @@ SRC = \
 	../checkout_externals.py \
 	../manic/*.py
 
-EXE = ../checkout_externals.py
+CHECKOUT_EXE = ../checkout_externals.py
 
 TEST_DIR = .
+
+README = ../README.md
 
 utest : FORCE
 	$(PYPATH) $(PYTHON) -m unittest discover --buffer --pattern 'test_unit_*.py'
@@ -37,9 +39,10 @@ stest : FORCE
 test : utest
 
 readme : FORCE
-	echo '-- AUTOMATICALLY GENERATED FILE. DO NOT EDIT --\n' > ../README
-	echo '[![Build Status](https://travis-ci.org/NCAR/manage_externals.svg?branch=master)](https://travis-ci.org/NCAR/manage_externals)\n' >> ../README
-	$(EXE) --help >> ../README
+	echo '-- AUTOMATICALLY GENERATED FILE. DO NOT EDIT --\n' > $(README)
+	echo '[![Build Status](https://travis-ci.org/NCAR/manage_externals.svg?branch=master)](https://travis-ci.org/NCAR/manage_externals)\n' >> $(README)
+	echo '```\n' >> $(README)
+	$(CHECKOUT_EXE) --help >> $(README)
 
 style : FORCE
 	$(AUTOPEP8) $(AUTOPEP8_ARGS) --recursive $(SRC) $(TEST_DIR)/test_*.py


### PR DESCRIPTION
Convert readme file to markdown

Rename the readme file with a markdown extension, then update a couple of
formatting rules so it will display reasonably on github and the terminal.

Update the text of the discussion about source root to clarify where
checkout_externals should be run from (GH-10, GH-11)

Testing: regenerate readme file.
