### PR TITLE
Bugfix for python3, enable python3 testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,13 @@
 #  on mac os. As a work around, we declare as a 'generic', use built-in
 #  python on linux, and manually install python with homebrew on osx.
 
-language: generic
+language: python
+os: linux
+python: 
+  - "2.7"
+  - "3.6"
 matrix:
   include:
-  - os: linux
-    language: python
-    python: 2.7
   - os: osx
     language: generic
     before_install:

--- a/manic/externals_description.py
+++ b/manic/externals_description.py
@@ -354,7 +354,8 @@ class ExternalsDescriptionConfigV1(ExternalsDescription):
             self[name] = {}
             self[name].update(list_to_dict(cfg_data.items(section)))
             self[name][self.REPO] = {}
-            for item in self[name].keys():
+            loop_keys = self[name].copy().keys()
+            for item in loop_keys:
                 if item in self._source_schema:
                     if isinstance(self._source_schema[item], bool):
                         self[name][item] = str_to_bool(self[name][item])


### PR DESCRIPTION
Python3 is more strict about not allowing a loop over keys to be modified
inplace. Copy the key list prior to starting a loop when we need to delete
items.

Enable linux-python3 testing on travis-ci.

Testing:
  python2 unit tests - pass
  python3 unit tests - pass
  python2 manual testing checkout, checkout status - ok
  python3 manual testing checkout, checkout status - ok


