### PR TITLE
UI: consistent use of externals instead of model

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,15 @@
 -- AUTOMATICALLY GENERATED FILE. DO NOT EDIT --
 
-[![Build Status](https://travis-ci.org/NCAR/manage_externals.svg?branch=master)](https://travis-ci.org/NCAR/manage_externals)
-
+-n [![Build Status](https://travis-ci.org/NCAR/manage_externals.svg?branch=master)](https://travis-ci.org/NCAR/manage_externals)
 [![Coverage Status](https://coveralls.io/repos/github/NCAR/manage_externals/badge.svg?branch=master)](https://coveralls.io/github/NCAR/manage_externals?branch=master)
 ```
 
-usage: checkout_externals.py [-h] [-m [MODEL]] [-o] [-S] [-v] [--backtrace]
-                             [-d]
+usage: checkout_externals.py [-h] [-e [EXTERNALS]] [-o] [-S] [-v]
+                             [--backtrace] [-d]
 
 checkout_externals.py manages checking out CESM externals from revision control
 based on a externals description file. By default only the required
-components of the model are checkout out.
+externals are checkout out.
 
 NOTE: checkout_externals.py *MUST* be run from the root of the source tree.
 
@@ -19,11 +18,11 @@ synchronize the working copy with the externals description.
 
 optional arguments:
   -h, --help            show this help message and exit
-  -m [MODEL], --model [MODEL]
+  -e [EXTERNALS], --externals [EXTERNALS]
                         The externals description filename. Default: CESM.cfg.
-  -o, --optional        By default only the required model components are
-                        checked out. This flag will also checkout the optional
-                        componets of the model.
+  -o, --optional        By default only the required externals are checked
+                        out. This flag will also checkout the optional
+                        externals.
   -S, --status          Output status of the repositories managed by
                         checkout_externals.py. By default only summary
                         information is provided. Use verbose output to see
@@ -54,7 +53,7 @@ The root of the source tree will be referred to as `${SRC_ROOT}` below.
 
 # Supported workflows
 
-  * Checkout all required components from the default model
+  * Checkout all required components from the default externals
     description file:
 
         $ cd ${SRC_ROOT}
@@ -68,15 +67,15 @@ The root of the source tree will be referred to as `${SRC_ROOT}` below.
 
     If there are *any* modifications to *any* working copy according
     to the git or svn 'status' command, checkout_externals.py
-    will not update any repositories in the model. Modifications
+    will not update any external repositories. Modifications
     include: modified files, added files, removed files, missing
     files or untracked files,
 
-  * Checkout all required components from a user specified model
+  * Checkout all required components from a user specified externals
     description file:
 
         $ cd ${SRC_ROOT}
-        $ ./manage_externals/checkout_externals.py --model myCESM.xml
+        $ ./manage_externals/checkout_externals.py --excernals myCESM.xml
 
   * Status summary of the repositories managed by checkout_externals.py:
 
@@ -115,10 +114,11 @@ The root of the source tree will be referred to as `${SRC_ROOT}` below.
         $ cd ${SRC_ROOT}
         $ ./manage_externals/checkout_externals.py --status --verbose
 
-# Model description file
+# Externals description file
 
-  The externals description contains a list of the model components that
-  are used and their version control locations. Each component has:
+  The externals description contains a list of the external
+  repositories that are used and their version control locations. Each
+  external has:
 
   * name (string) : component name, e.g. cime, cism, clm, cam, etc.
 
@@ -131,23 +131,36 @@ The root of the source tree will be referred to as `${SRC_ROOT}` below.
     manage the component.  Valid values are 'git', 'svn',
     'externals_only'.
 
-    Note: 'externals_only' will only process the externals model
-    description file without trying to manage a repository for the
-    component. This is used for retreiving externals for standalone
-    components like cam and clm.
+    Note: 'externals_only' will only process the external's own
+    external description file without trying to manage a repository
+    for the component. This is used for retreiving externals for
+    standalone components like cam and clm.
 
   * repo_url (string) : URL for the repository location, examples:
-    * svn - https://svn-ccsm-models.cgd.ucar.edu/glc
-    * git - git@github.com:esmci/cime.git
-    * local - /path/to/local/repository
+    * https://svn-ccsm-models.cgd.ucar.edu/glc
+    * git@github.com:esmci/cime.git
+    * /path/to/local/repository
+
+    If a repo url is determined to be a local path (not a network url)
+    then user expansion, e.g. ~/, and environment variable expansion,
+    e.g. $HOME or $REPO_ROOT, will be performed.
+
+    Relative paths are difficult to get correct, especially for mixed
+    use repos like clm. It is advised that local paths expand to
+    absolute paths. If relative paths are used, they should be
+    relative to one level above local_path. If local path is
+    'src/foo', the the relative url should be relative to
+    'src'.
 
   * tag (string) : tag to checkout
 
   * branch (string) : branch to checkout
 
-  * externals (string) : relative path to the external model
+    Note: either tag or branch must be supplied, but not both.
+
+  * externals (string) : relative path to the external's own external
     description file that should also be used. It is *relative* to the
-    component local_path. For example, the CESM externals description will
-    load clm. CLM has additional externals that must be downloaded to
-    be complete. Those additional externals are managed from the clm
-    source root by the file pointed to by 'externals'.
+    component local_path. For example, the CESM externals description
+    will load clm. CLM has additional externals that must be
+    downloaded to be complete. Those additional externals are managed
+    from the clm source root by the file pointed to by 'externals'.

--- a/checkout_externals.py
+++ b/checkout_externals.py
@@ -48,7 +48,7 @@ def commandline_arguments(args=None):
     description = '''
 %(prog)s manages checking out CESM externals from revision control
 based on a externals description file. By default only the required
-components of the model are checkout out.
+externals are checkout out.
 
 NOTE: %(prog)s *MUST* be run from the root of the source tree.
 
@@ -77,7 +77,7 @@ The root of the source tree will be referred to as `${SRC_ROOT}` below.
 
 # Supported workflows
 
-  * Checkout all required components from the default model
+  * Checkout all required components from the default externals
     description file:
 
         $ cd ${SRC_ROOT}
@@ -91,15 +91,15 @@ The root of the source tree will be referred to as `${SRC_ROOT}` below.
 
     If there are *any* modifications to *any* working copy according
     to the git or svn 'status' command, %(prog)s
-    will not update any repositories in the model. Modifications
+    will not update any external repositories. Modifications
     include: modified files, added files, removed files, missing
     files or untracked files,
 
-  * Checkout all required components from a user specified model
+  * Checkout all required components from a user specified externals
     description file:
 
         $ cd ${SRC_ROOT}
-        $ ./manage_externals/%(prog)s --model myCESM.xml
+        $ ./manage_externals/%(prog)s --excernals myCESM.xml
 
   * Status summary of the repositories managed by %(prog)s:
 
@@ -139,10 +139,11 @@ The root of the source tree will be referred to as `${SRC_ROOT}` below.
         $ cd ${SRC_ROOT}
         $ ./manage_externals/%(prog)s --status --verbose
 
-# Model description file
+# Externals description file
 
-  The externals description contains a list of the model components that
-  are used and their version control locations. Each component has:
+  The externals description contains a list of the external
+  repositories that are used and their version control locations. Each
+  external has:
 
   * name (string) : component name, e.g. cime, cism, clm, cam, etc.
 
@@ -155,10 +156,10 @@ The root of the source tree will be referred to as `${SRC_ROOT}` below.
     manage the component.  Valid values are 'git', 'svn',
     'externals_only'.
 
-    Note: 'externals_only' will only process the externals model
-    description file without trying to manage a repository for the
-    component. This is used for retreiving externals for standalone
-    components like cam and clm.
+    Note: 'externals_only' will only process the external's own
+    external description file without trying to manage a repository
+    for the component. This is used for retreiving externals for
+    standalone components like cam and clm.
 
   * repo_url (string) : URL for the repository location, examples:
     * https://svn-ccsm-models.cgd.ucar.edu/glc
@@ -182,12 +183,12 @@ The root of the source tree will be referred to as `${SRC_ROOT}` below.
 
     Note: either tag or branch must be supplied, but not both.
 
-  * externals (string) : relative path to the external model
+  * externals (string) : relative path to the external's own external
     description file that should also be used. It is *relative* to the
-    component local_path. For example, the CESM externals description will
-    load clm. CLM has additional externals that must be downloaded to
-    be complete. Those additional externals are managed from the clm
-    source root by the file pointed to by 'externals'.
+    component local_path. For example, the CESM externals description
+    will load clm. CLM has additional externals that must be
+    downloaded to be complete. Those additional externals are managed
+    from the clm source root by the file pointed to by 'externals'.
 
 '''
 
@@ -198,14 +199,14 @@ The root of the source tree will be referred to as `${SRC_ROOT}` below.
     #
     # user options
     #
-    parser.add_argument('-m', '--model', nargs='?', default='CESM.cfg',
+    parser.add_argument('-e', '--externals', nargs='?', default='CESM.cfg',
                         help='The externals description filename. '
                         'Default: %(default)s.')
 
     parser.add_argument('-o', '--optional', action='store_true', default=False,
-                        help='By default only the required model components '
+                        help='By default only the required externals '
                         'are checked out. This flag will also checkout the '
-                        'optional componets of the model.')
+                        'optional externals.')
 
     parser.add_argument('-S', '--status', action='store_true', default=False,
                         help='Output status of the repositories managed by '
@@ -242,7 +243,7 @@ The root of the source tree will be referred to as `${SRC_ROOT}` below.
 def main(args):
     """
     Function to call when module is called from the command line.
-    Parse model file and load required repositories or all repositories if
+    Parse externals file and load required repositories or all repositories if
     the --all option is passed.
     """
     logging.basicConfig(filename='manage_externals.log',
@@ -257,12 +258,12 @@ def main(args):
         load_all = True
 
     root_dir = os.path.abspath('.')
-    model_data = read_externals_description_file(root_dir, args.model)
-    model = create_externals_description(model_data)
+    external_data = read_externals_description_file(root_dir, args.externals)
+    external = create_externals_description(external_data)
     if args.debug:
-        PPRINTER.pprint(model)
+        PPRINTER.pprint(external)
 
-    source_tree = SourceTree(root_dir, model)
+    source_tree = SourceTree(root_dir, external)
     printlog('Checking status of components: ', end='')
     tree_status = source_tree.status()
     printlog('')
@@ -276,7 +277,7 @@ def main(args):
             # user requested verbose status dump of the git/svn status commands
             source_tree.verbose_status()
     else:
-        # checkout / update the model repositories.
+        # checkout / update the external repositories.
         safe_to_update = check_safe_to_update_repos(tree_status, args.debug)
         if not safe_to_update:
             # print status
@@ -285,8 +286,8 @@ def main(args):
                 printlog(msg)
             # exit gracefully
             msg = textwrap.fill(
-                'Model contains repositories that are not in a clean '
-                'state. Please all external repositories are clean '
+                'Some external repositories that are not in a clean '
+                'state. Please ensure all external repositories are clean '
                 'before updating.')
             printlog('-' * 70)
             printlog(msg)

--- a/test/Makefile
+++ b/test/Makefile
@@ -56,7 +56,7 @@ test : utest stest
 .PHONY : readme
 readme : $(CHECKOUT_EXE)
 	echo '-- AUTOMATICALLY GENERATED FILE. DO NOT EDIT --\n' > $(README)
-	echo '[![Build Status](https://travis-ci.org/NCAR/manage_externals.svg?branch=master)](https://travis-ci.org/NCAR/manage_externals)\n' >> $(README)
+	echo -n '[![Build Status](https://travis-ci.org/NCAR/manage_externals.svg?branch=master)](https://travis-ci.org/NCAR/manage_externals)' >> $(README)
 	echo '[![Coverage Status](https://coveralls.io/repos/github/NCAR/manage_externals/badge.svg?branch=master)](https://coveralls.io/github/NCAR/manage_externals?branch=master)' >> $(README)
 	echo '```\n' >> $(README)
 	$(CHECKOUT_EXE) --help >> $(README)

--- a/test/develop.rst
+++ b/test/develop.rst
@@ -178,6 +178,8 @@ functions, class methods, and groups of functions and class methods.
 System Integration Tests
 ------------------------
 
+NOTE(bja, 2017-11) The systems integration tests currently do not include svn repositories.
+
 The manage_externals package is extremely tedious and error prone to test manually.
 
 Combinations that must be tested to ensure basic functionality are:

--- a/test/test_sys_checkout.py
+++ b/test/test_sys_checkout.py
@@ -274,7 +274,7 @@ class TestSysCheckout(unittest.TestCase):
         """
         cwd = os.getcwd()
         os.chdir(under_test_dir)
-        cmdline = ['--model', CFG_NAME, ]
+        cmdline = ['--externals', CFG_NAME, ]
         cmdline += args
         options = checkout_externals.commandline_arguments(cmdline)
         status = checkout_externals.main(options)


### PR DESCRIPTION
Update the command line interface and doc, replacing 'model' with 'externals'

User interface changes: yes
  checkout_externals - command line -m --model is now -e --externals

Testing:
  python2 test suite - pass
  python3 test suite - pass
  python2 manual test - checkout status - ok
  python3 manual test - checkout status - ok

Closes GH-23