### PR TITLE
Bugfix handling subprocess output.

### DIFF
--- a/manic/utils.py
+++ b/manic/utils.py
@@ -133,8 +133,8 @@ def execute_subprocess(commands, status_to_caller=False):
     status = -1
     try:
         logging.info(' '.join(commands))
-        output = subprocess.check_output(commands, stderr=subprocess.STDOUT)
-        output = output.decode('ascii')
+        output = subprocess.check_output(commands, stderr=subprocess.STDOUT,
+                                         universal_newlines=True)
         log_process_output(output)
         status = 0
     except OSError as error:

--- a/manic/utils.py
+++ b/manic/utils.py
@@ -41,6 +41,7 @@ def printlog(msg, **kwargs):
         print(msg, **kwargs)
     else:
         print(msg)
+    sys.stdout.flush()
 
 
 # ---------------------------------------------------------------------


### PR DESCRIPTION
Bugfix handling subprocess output.
    
python3 would generate an attribute error while handling fatal errors from
subprocess output. It was working on a byte string where a unicode string was
expected. Change to using universal_newlines in subprocess call so that we
always get back a unicode string.

Flush stdout everytime printlog is done to ensure user can see progress when a series of long subprocess calls are being executed. GH-28

Testing:
    python2/3 - unit tests - pass
    python2/3 - manual testing ok.
