### PR TITLE
Improve branch and tag error checking.

### DIFF
--- a/manic/repository_git.py
+++ b/manic/repository_git.py
@@ -304,11 +304,11 @@ class GitRepository(Repository):
             self._git_remote_add(remote_name, self._url)
         self._git_fetch(remote_name)
         if self._tag:
-            is_unique_tag = self._is_unique_tag(self._tag)
+            is_unique_tag, check_msg = self._is_unique_tag(self._tag,
+                                                           remote_name)
             if not is_unique_tag:
-                msg = ('In repo "{1}": tag "{0}" is either not a valid '
-                       'reference or is shadowed by a branch.'.format(
-                           self._tag, self._name))
+                msg = ('In repo "{0}": tag "{1}" {2}'.format(
+                    self._name, self._tag, check_msg))
                 fatal_error(msg)
             ref = self._tag
         else:
@@ -316,7 +316,7 @@ class GitRepository(Repository):
         self._git_checkout_ref(ref)
         os.chdir(cwd)
 
-    def _is_unique_tag(self, ref):
+    def _is_unique_tag(self, ref, remote_name):
         """Verify that a reference is a valid tag and is unique (not a branch)
 
         Tags may be tag names, or SHA id's. It is also possible that a
@@ -328,17 +328,37 @@ class GitRepository(Repository):
 
         """
         is_tag = self._ref_is_tag(ref)
-        is_branch = self._ref_is_branch(ref)
+        is_branch = self._ref_is_branch(ref, remote_name)
         is_commit = self._ref_is_commit(ref)
 
+        msg = ''
         is_unique_tag = False
         if is_tag and not is_branch:
             # unique tag
+            msg = 'is ok'
             is_unique_tag = True
-        if not is_branch and is_commit:
-            # probably a sha1 or HEAD, etc, we call it a tag
-            is_unique_tag = True
-        return is_unique_tag
+        elif is_tag and is_branch:
+            msg = ('is both a branch and a tag. git may checkout the branch '
+                   'instead of the tag depending on your version of git.')
+            is_unique_tag = False
+        elif not is_tag and is_branch:
+            msg = ('is a branch, and not a tag. If you intended to checkout '
+                   'a branch, please change the externals description to be '
+                   'a branch. If you intended to checkout a tag, it does not '
+                   'exist. Please check the name.')
+            is_unique_tag = False
+        else:  # not is_tag and not is_branch:
+            if is_commit:
+                # probably a sha1 or HEAD, etc, we call it a tag
+                msg = 'is ok'
+                is_unique_tag = True
+            else:
+                # undetermined state.
+                msg = ('does not appear to be a valid tag, branch or commit! '
+                       'Please check the name and repository.')
+                is_unique_tag = False
+
+        return is_unique_tag, msg
 
     def _ref_is_tag(self, ref):
         """Verify that a reference is a valid tag according to git.
@@ -353,15 +373,50 @@ class GitRepository(Repository):
             is_tag = True
         return is_tag
 
-    def _ref_is_branch(self, ref):
+    def _ref_is_branch(self, ref, remote_name):
+        """Verify if a ref is any kind of branch (local, tracked remote,
+        untracked remote).
+
+        """
+        untracked_remote = self._ref_is_remote_branch(ref, remote_name)
+        local = self._ref_is_local_branch(ref)
+        is_branch = False
+        if untracked_remote is True or local is True:
+            is_branch = True
+        return is_branch
+
+    def _ref_is_local_branch(self, ref):
         """Verify that a reference is a valid branch according to git.
+
+        show-ref branch returns local branches that have been
+        previously checked out. It will not necessarily pick up
+        untracked remote branches.
 
         Note: values returned by git_showref_* and git_revparse are
         shell return codes, which are zero for success, non-zero for
         error!
+
         """
         is_branch = False
         value = self._git_showref_branch(ref)
+        if value == 0:
+            is_branch = True
+        return is_branch
+
+    def _ref_is_remote_branch(self, ref, remote_name):
+        """Verify that a reference is a valid branch according to git.
+
+        show-ref branch returns local branches that have been
+        previously checked out. It will not necessarily pick up
+        untracked remote branches.
+
+        Note: values returned by git_showref_* and git_revparse are
+        shell return codes, which are zero for success, non-zero for
+        error!
+
+        """
+        is_branch = False
+        value = self._git_lsremote_branch(ref, remote_name)
         if value == 0:
             is_branch = True
         return is_branch
@@ -459,11 +514,23 @@ class GitRepository(Repository):
 
     @staticmethod
     def _git_showref_branch(ref):
-        """Run git show-ref check if the user supplied ref is a branch.
+        """Run git show-ref check if the user supplied ref is a local or
+        tracked remote branch.
 
         """
         cmd = ['git', 'show-ref', '--quiet', '--verify',
                'refs/heads/{0}'.format(ref), ]
+        status = execute_subprocess(cmd, status_to_caller=True)
+        return status
+
+    @staticmethod
+    def _git_lsremote_branch(ref, remote_name):
+        """Run git ls-remote to check if the user supplied ref is a remote
+        branch that is not being tracked
+
+        """
+        cmd = ['git', 'ls-remote', '--exit-code', '--heads',
+               remote_name, ref, ]
         status = execute_subprocess(cmd, status_to_caller=True)
         return status
 


### PR DESCRIPTION
Introduction of remotes and tag checks didn't cover enough edge cases for
determining if something is a branch or tag, and didn't report helpful error
messages. Untracked remote branches were being reported as invalid refs rather
than valid branches that could be checkoud out.

Testing:
  python2/3 - make test - pass
  python2/3 - manual checkout, status - ok

User interface changes?: No
