### PR TITLE
refactor and code cleanup

### DIFF
--- a/checkout_externals
+++ b/checkout_externals
@@ -26,7 +26,7 @@ if sys.hexversion < 0x02070000:
 
 
 if __name__ == '__main__':
-    logging.basicConfig(filename='manage_externals.log',
+    logging.basicConfig(filename=manic.global_constants.LOG_FILE_NAME,
                         format='%(levelname)s : %(asctime)s : %(message)s',
                         datefmt='%Y-%m-%d %H:%M:%S',
                         level=logging.DEBUG)

--- a/manic/checkout.py
+++ b/manic/checkout.py
@@ -22,13 +22,13 @@ from manic.externals_description import read_externals_description_file
 from manic.externals_status import check_safe_to_update_repos
 from manic.sourcetree import SourceTree
 from manic.utils import printlog
-from manic.global_constants import PPRINTER
+from manic.global_constants import PPRINTER, VERSION_SEPERATOR
 
 if sys.hexversion < 0x02070000:
     print(70 * '*')
     print('ERROR: {0} requires python >= 2.7.x. '.format(sys.argv[0]))
     print('It appears that you are running python {0}'.format(
-        '.'.join(str(x) for x in sys.version_info[0:3])))
+        VERSION_SEPERATOR.join(str(x) for x in sys.version_info[0:3])))
     print(70 * '*')
     sys.exit(1)
 
@@ -253,7 +253,7 @@ def main(args):
     if args.optional:
         load_all = True
 
-    root_dir = os.path.abspath('.')
+    root_dir = os.path.abspath(os.getcwd())
     external_data = read_externals_description_file(root_dir, args.externals)
     external = create_externals_description(external_data)
     if args.debug:

--- a/manic/externals_description.py
+++ b/manic/externals_description.py
@@ -49,7 +49,7 @@ except ImportError:
         return text
 
 from .utils import printlog, fatal_error, str_to_bool, expand_local_url
-from .global_constants import EMPTY_STR, PPRINTER
+from .global_constants import EMPTY_STR, PPRINTER, VERSION_SEPERATOR
 
 #
 # Globals
@@ -134,7 +134,7 @@ def get_cfg_schema_version(model_cfg):
     # build/pre-release metadata for now!
     version_list = re.split(r'[-+]', semver_str)
     version_str = version_list[0]
-    version = version_str.split('.')
+    version = version_str.split(VERSION_SEPERATOR)
     try:
         major = int(version[0].strip())
         minor = int(version[1].strip())

--- a/manic/externals_description.py
+++ b/manic/externals_description.py
@@ -205,38 +205,38 @@ class ExternalsDescription(dict):
     def _check_data(self):
         """Check user supplied data is valid where possible.
         """
-        for field in self.keys():
-            if (self[field][self.REPO][self.PROTOCOL]
+        for ext_name in self.keys():
+            if (self[ext_name][self.REPO][self.PROTOCOL]
                     not in self.KNOWN_PRROTOCOLS):
                 msg = 'Unknown repository protocol "{0}" in "{1}".'.format(
-                    self[field][self.REPO][self.PROTOCOL], field)
+                    self[ext_name][self.REPO][self.PROTOCOL], ext_name)
                 fatal_error(msg)
 
-            if (self[field][self.REPO][self.PROTOCOL]
+            if (self[ext_name][self.REPO][self.PROTOCOL]
                     != self.PROTOCOL_EXTERNALS_ONLY):
-                if (self[field][self.REPO][self.TAG] and
-                        self[field][self.REPO][self.BRANCH]):
+                if (self[ext_name][self.REPO][self.TAG] and
+                        self[ext_name][self.REPO][self.BRANCH]):
                     msg = ('Model description is over specified! Can not '
                            'have both "tag" and "branch" in repo '
-                           'description for "{0}"'.format(field))
+                           'description for "{0}"'.format(ext_name))
                     fatal_error(msg)
 
-                if (not self[field][self.REPO][self.TAG] and
-                        not self[field][self.REPO][self.BRANCH]):
+                if (not self[ext_name][self.REPO][self.TAG] and
+                        not self[ext_name][self.REPO][self.BRANCH]):
                     msg = ('Model description is under specified! Must have '
                            'either "tag" or "branch" in repo '
-                           'description for "{0}"'.format(field))
+                           'description for "{0}"'.format(ext_name))
                     fatal_error(msg)
 
-                if not self[field][self.REPO][self.REPO_URL]:
+                if not self[ext_name][self.REPO][self.REPO_URL]:
                     msg = ('Model description is under specified! Must have '
                            'either "repo_url" in repo '
-                           'description for "{0}"'.format(field))
+                           'description for "{0}"'.format(ext_name))
                     fatal_error(msg)
 
                 url = expand_local_url(
-                    self[field][self.REPO][self.REPO_URL], field)
-                self[field][self.REPO][self.REPO_URL] = url
+                    self[ext_name][self.REPO][self.REPO_URL], ext_name)
+                self[ext_name][self.REPO][self.REPO_URL] = url
 
     def _check_optional(self):
         """Some fields like externals, repo:tag repo:branch are

--- a/manic/global_constants.py
+++ b/manic/global_constants.py
@@ -8,4 +8,6 @@ from __future__ import print_function
 import pprint
 
 EMPTY_STR = ''
+LOCAL_PATH_INDICATOR = '.'
+VERSION_SEPERATOR = '.'
 PPRINTER = pprint.PrettyPrinter(indent=4)

--- a/manic/global_constants.py
+++ b/manic/global_constants.py
@@ -10,4 +10,5 @@ import pprint
 EMPTY_STR = ''
 LOCAL_PATH_INDICATOR = '.'
 VERSION_SEPERATOR = '.'
+LOG_FILE_NAME = 'manage_externals.log'
 PPRINTER = pprint.PrettyPrinter(indent=4)

--- a/manic/repository_git.py
+++ b/manic/repository_git.py
@@ -9,7 +9,7 @@ import copy
 import os
 import re
 
-from .global_constants import EMPTY_STR
+from .global_constants import EMPTY_STR, LOCAL_PATH_INDICATOR
 from .repository import Repository
 from .externals_status import ExternalStatus
 from .utils import expand_local_url, split_remote_url, is_remote_url
@@ -217,7 +217,7 @@ class GitRepository(Repository):
         if current_ref == EMPTY_STR:
             stat.sync_state = ExternalStatus.UNKNOWN
         elif self._branch:
-            if self._url == '.':
+            if self._url == LOCAL_PATH_INDICATOR:
                 expected_ref = self._branch
                 stat.sync_state = compare_refs(current_ref, expected_ref)
             else:
@@ -309,7 +309,7 @@ class GitRepository(Repository):
         # import pdb; pdb.set_trace()
         cwd = os.getcwd()
         os.chdir(repo_dir)
-        if self._url.strip() == '.':
+        if self._url.strip() == LOCAL_PATH_INDICATOR:
             self._checkout_local_ref()
         else:
             self._checkout_external_ref()

--- a/manic/repository_git.py
+++ b/manic/repository_git.py
@@ -14,7 +14,7 @@ from .repository import Repository
 from .externals_status import ExternalStatus
 from .utils import expand_local_url, split_remote_url, is_remote_url
 from .utils import log_process_output, fatal_error
-from .utils import execute_subprocess, check_output
+from .utils import execute_subprocess
 
 
 class GitRepository(Repository):
@@ -25,7 +25,8 @@ class GitRepository(Repository):
     * be isolated in separate functions with no application logic
       * of the form:
          - cmd = ['git', ...]
-         - value = check_output(cmd)
+         - value = execute_subprocess(cmd, output_to_caller={T|F},
+                                      status_to_caller={T|F})
          - return value
       * be static methods (not rely on self)
       * name as _git_subcommand_args(user_args)
@@ -553,7 +554,7 @@ class GitRepository(Repository):
 
         """
         cmd = ['git', 'branch', '--verbose', '--verbose']
-        git_output = check_output(cmd)
+        git_output = execute_subprocess(cmd, output_to_caller=True)
         return git_output
 
     @staticmethod
@@ -609,7 +610,7 @@ class GitRepository(Repository):
 
         """
         cmd = ['git', 'status', '--porcelain', '-z']
-        git_output = check_output(cmd)
+        git_output = execute_subprocess(cmd, output_to_caller=True)
         return git_output
 
     @staticmethod
@@ -617,7 +618,7 @@ class GitRepository(Repository):
         """Run the git status command to obtain repository information.
         """
         cmd = ['git', 'status']
-        git_output = check_output(cmd)
+        git_output = execute_subprocess(cmd, output_to_caller=True)
         return git_output
 
     @staticmethod
@@ -625,7 +626,7 @@ class GitRepository(Repository):
         """Run the git remote command to obtain repository information.
         """
         cmd = ['git', 'remote', '--verbose']
-        git_output = check_output(cmd)
+        git_output = execute_subprocess(cmd, output_to_caller=True)
         return git_output
 
     # ----------------------------------------------------------------

--- a/manic/repository_svn.py
+++ b/manic/repository_svn.py
@@ -12,7 +12,7 @@ import xml.etree.ElementTree as ET
 from .repository import Repository
 from .externals_status import ExternalStatus
 from .utils import fatal_error, log_process_output
-from .utils import check_output, execute_subprocess
+from .utils import execute_subprocess
 
 
 class SvnRepository(Repository):
@@ -24,7 +24,8 @@ class SvnRepository(Repository):
     * be isolated in separate functions with no application logic
       * of the form:
          - cmd = ['svn', ...]
-         - value = check_output(cmd)
+         - value = execute_subprocess(cmd, output_to_caller={T|F},
+                                      status_to_caller={T|F})
          - return value
       * be static methods (not rely on self)
       * name as _svn_subcommand_args(user_args)
@@ -189,7 +190,7 @@ class SvnRepository(Repository):
         """Return results of svn info command
         """
         cmd = ['svn', 'info', repo_dir_path]
-        output = check_output(cmd)
+        output = execute_subprocess(cmd, output_to_caller=True)
         return output
 
     @staticmethod
@@ -197,7 +198,7 @@ class SvnRepository(Repository):
         """capture the full svn status output
         """
         cmd = ['svn', 'status', repo_dir_path]
-        svn_output = check_output(cmd)
+        svn_output = execute_subprocess(cmd, output_to_caller=True)
         return svn_output
 
     @staticmethod
@@ -206,7 +207,7 @@ class SvnRepository(Repository):
         Get status of the subversion sandbox in repo_dir
         """
         cmd = ['svn', 'status', '--xml', repo_dir_path]
-        svn_output = check_output(cmd)
+        svn_output = execute_subprocess(cmd, output_to_caller=True)
         return svn_output
 
     # ----------------------------------------------------------------

--- a/manic/sourcetree.py
+++ b/manic/sourcetree.py
@@ -60,7 +60,8 @@ class _External(object):
         self._externals = ext_description[ExternalsDescription.EXTERNALS]
         if self._externals:
             self._create_externals_sourcetree()
-        repo = create_repository(name, ext_description[ExternalsDescription.REPO])
+        repo = create_repository(
+            name, ext_description[ExternalsDescription.REPO])
         if repo:
             self._repo = repo
 

--- a/manic/sourcetree.py
+++ b/manic/sourcetree.py
@@ -14,7 +14,7 @@ from .externals_description import create_externals_description
 from .repository_factory import create_repository
 from .externals_status import ExternalStatus
 from .utils import fatal_error, printlog
-from .global_constants import EMPTY_STR
+from .global_constants import EMPTY_STR, LOCAL_PATH_INDICATOR
 
 
 class _Source(object):
@@ -89,9 +89,10 @@ class _Source(object):
         stat.path = self.get_local_path()
         if not self._required:
             stat.source_type = ExternalStatus.OPTIONAL
-        elif self._local_path == '.':
-            # '.' paths are standalone component directories that are
-            # not managed by checkout_externals.
+        elif self._local_path == LOCAL_PATH_INDICATOR:
+            # LOCAL_PATH_INDICATOR, '.' paths, are standalone
+            # component directories that are not managed by
+            # checkout_externals.
             stat.source_type = ExternalStatus.STANDALONE
         else:
             # managed by checkout_externals
@@ -120,7 +121,7 @@ class _Source(object):
         all_stats = {}
         # don't add the root component because we don't manage it
         # and can't provide useful info about it.
-        if self._local_path != '.':
+        if self._local_path != LOCAL_PATH_INDICATOR:
             # store the stats under tha local_path, not comp name so
             # it will be sorted correctly
             all_stats[stat.path] = stat
@@ -223,7 +224,7 @@ class SourceTree(object):
             if model[comp][ExternalsDescription.REQUIRED]:
                 self._required_compnames.append(comp)
 
-    def status(self, relative_path_base='.'):
+    def status(self, relative_path_base=LOCAL_PATH_INDICATOR):
         """Report the status components
 
         FIXME(bja, 2017-10) what do we do about situations where the

--- a/manic/sourcetree.py
+++ b/manic/sourcetree.py
@@ -1,6 +1,6 @@
 """
 
-FIXME(bja, 2017-11) Source and SourceTree have a circular dependancy!
+FIXME(bja, 2017-11) External and SourceTree have a circular dependancy!
 """
 
 import errno
@@ -17,25 +17,25 @@ from .utils import fatal_error, printlog
 from .global_constants import EMPTY_STR, LOCAL_PATH_INDICATOR
 
 
-class _Source(object):
+class _External(object):
     """
-    _Source represents a <source> object in a <config_sourcetree>
+    _External represents an external object in side a SourceTree
     """
 
     # pylint: disable=R0902
 
-    def __init__(self, root_dir, name, source):
-        """Parse an XML node for a <source> tag
+    def __init__(self, root_dir, name, ext_description):
+        """Parse an external description file into a dictionary of externals.
 
         Input:
 
             root_dir : string - the root directory path where
             'local_path' is relative to.
 
-            name : string - name of the source object. may or may not
+            name : string - name of the ext_description object. may or may not
             correspond to something in the path.
 
-            source : dict - source ExternalsDescription object
+            ext_description : dict - source ExternalsDescription object
 
         """
         self._name = name
@@ -45,7 +45,7 @@ class _Source(object):
         # Parse the sub-elements
 
         # _path : local path relative to the containing source tree
-        self._local_path = source[ExternalsDescription.PATH]
+        self._local_path = ext_description[ExternalsDescription.PATH]
         # _repo_dir : full repository directory
         repo_dir = os.path.join(root_dir, self._local_path)
         self._repo_dir_path = os.path.abspath(repo_dir)
@@ -56,33 +56,33 @@ class _Source(object):
         assert(os.path.join(self._base_dir_path, self._repo_dir_name)
                == self._repo_dir_path)
 
-        self._required = source[ExternalsDescription.REQUIRED]
-        self._externals = source[ExternalsDescription.EXTERNALS]
+        self._required = ext_description[ExternalsDescription.REQUIRED]
+        self._externals = ext_description[ExternalsDescription.EXTERNALS]
         if self._externals:
             self._create_externals_sourcetree()
-        repo = create_repository(name, source[ExternalsDescription.REPO])
+        repo = create_repository(name, ext_description[ExternalsDescription.REPO])
         if repo:
             self._repo = repo
 
     def get_name(self):
         """
-        Return the source object's name
+        Return the external object's name
         """
         return self._name
 
     def get_local_path(self):
         """
-        Return the source object's path
+        Return the external object's path
         """
         return self._local_path
 
     def status(self):
         """
         If the repo destination directory exists, ensure it is correct (from
-        correct URL, correct branch or tag), and possibly update the source.
+        correct URL, correct branch or tag), and possibly update the external.
         If the repo destination directory does not exist, checkout the correce
         branch or tag.
-        If load_all is True, also load all of the the sources sub-sources.
+        If load_all is True, also load all of the the externals sub-externals.
         """
 
         stat = ExternalStatus()
@@ -150,10 +150,10 @@ class _Source(object):
     def checkout(self, load_all):
         """
         If the repo destination directory exists, ensure it is correct (from
-        correct URL, correct branch or tag), and possibly update the source.
+        correct URL, correct branch or tag), and possibly update the external.
         If the repo destination directory does not exist, checkout the correce
         branch or tag.
-        If load_all is True, also load all of the the sources sub-sources.
+        If load_all is True, also load all of the the externals sub-externals.
         """
         if load_all:
             pass
@@ -208,18 +208,18 @@ class _Source(object):
 
 class SourceTree(object):
     """
-    SourceTree represents a <config_sourcetree> object
+    SourceTree represents a group of managed externals
     """
 
     def __init__(self, root_dir, model):
         """
-        Parse a model file into a SourceTree object
+        Build a SourceTree object from a model description
         """
         self._root_dir = os.path.abspath(root_dir)
         self._all_components = {}
         self._required_compnames = []
         for comp in model:
-            src = _Source(self._root_dir, comp, model[comp])
+            src = _External(self._root_dir, comp, model[comp])
             self._all_components[comp] = src
             if model[comp][ExternalsDescription.REQUIRED]:
                 self._required_compnames.append(comp)
@@ -270,9 +270,9 @@ class SourceTree(object):
         Checkout or update indicated components into the the configured
         subdirs.
 
-        If load_all is True, recursively checkout all sources.
+        If load_all is True, recursively checkout all externals.
         If load_all is False, load_comp is an optional set of components to load.
-        If load_all is True and load_comp is None, only load the required sources.
+        If load_all is True and load_comp is None, only load the required externals.
         """
         if load_all:
             load_comps = self._all_components.keys()

--- a/manic/utils.py
+++ b/manic/utils.py
@@ -13,12 +13,15 @@ import os
 import subprocess
 import sys
 
+from .global_constants import LOCAL_PATH_INDICATOR
 
 # ---------------------------------------------------------------------
 #
 # screen and logging output
 #
 # ---------------------------------------------------------------------
+
+
 def log_process_output(output):
     """Log each line of process output at debug level so it can be
     filtered if necessary. By default, output is a single string, and
@@ -122,13 +125,13 @@ def expand_local_url(url, field):
     remote. If so, it must be expanded to an absolute
     path.
 
-    Note: local paths of '.' have special meaning and represent local
-    copy only, don't work with the remotes.
+    Note: local paths of LOCAL_PATH_INDICATOR have special meaning and
+    represent local copy only, don't work with the remotes.
 
     """
     remote_url = is_remote_url(url)
     if not remote_url:
-        if url.strip() == '.':
+        if url.strip() == LOCAL_PATH_INDICATOR:
             pass
         else:
             url = os.path.expandvars(url)

--- a/manic/utils.py
+++ b/manic/utils.py
@@ -10,10 +10,11 @@ from __future__ import print_function
 
 import logging
 import os
+import string
 import subprocess
 import sys
 
-from .global_constants import LOCAL_PATH_INDICATOR
+from .global_constants import LOCAL_PATH_INDICATOR, LOG_FILE_NAME
 
 # ---------------------------------------------------------------------
 #
@@ -152,36 +153,8 @@ def expand_local_url(url, field):
 # subprocess
 #
 # ---------------------------------------------------------------------
-def check_output(commands):
-    """
-    Wrapper around subprocess.check_output to handle common exceptions.
-    check_output runs a command with arguments and returns its output.
-    On successful completion, check_output returns the command's output.
-    """
-    msg = 'In directory: {0}\ncheck_output running command:'.format(
-        os.getcwd())
-    logging.info(msg)
-    logging.info(commands)
-    try:
-        output = subprocess.check_output(commands)
-        output = output.decode('ascii')
-        log_process_output(output)
-    except OSError as error:
-        printlog('Execution of "{0}" failed: {1}'.format(
-            (' '.join(commands)), error), file=sys.stderr)
-    except ValueError as error:
-        printlog('ValueError in "{0}": {1}'.format(
-            (' '.join(commands)), error), file=sys.stderr)
-        output = None
-    except subprocess.CalledProcessError as error:
-        printlog('CalledProcessError in "{0}": {1}'.format(
-            (' '.join(commands)), error), file=sys.stderr)
-        output = None
-
-    return output
-
-
-def execute_subprocess(commands, status_to_caller=False):
+def execute_subprocess(commands, status_to_caller=False,
+                       output_to_caller=False):
     """Wrapper around subprocess.check_output to handle common
     exceptions.
 
@@ -198,7 +171,9 @@ def execute_subprocess(commands, status_to_caller=False):
         os.getcwd())
     logging.info(msg)
     logging.info(commands)
+    return_to_caller = status_to_caller or output_to_caller
     status = -1
+    output = ''
     try:
         logging.info(' '.join(commands))
         output = subprocess.check_output(commands, stderr=subprocess.STDOUT,
@@ -206,23 +181,52 @@ def execute_subprocess(commands, status_to_caller=False):
         log_process_output(output)
         status = 0
     except OSError as error:
-        msg = 'Execution of "{0}" failed'.format(
-            ' '.join(commands))
+        msg = failed_command_msg(
+            'Command execution failed. Does the executable exist?',
+            commands)
         logging.error(error)
         fatal_error(msg)
     except ValueError as error:
-        msg = 'ValueError in "{0}"'.format(
-            ' '.join(commands))
+        msg = failed_command_msg(
+            'DEV_ERROR: Invalid arguments trying to run subprocess',
+            commands)
         logging.error(error)
         fatal_error(msg)
     except subprocess.CalledProcessError as error:
-        msg = 'CalledProcessError in "{0}"'.format(
-            ' '.join(commands))
+        msg = failed_command_msg(
+            'Called process did not run successfully.\n'
+            'Returned status: {0}'.format(error.returncode),
+            commands)
         logging.error(error)
-        status_msg = 'Returned : {0}'.format(error.returncode)
-        logging.error(status_msg)
+        logging.error(msg)
         log_process_output(error.output)
-        if not status_to_caller:
+        if not return_to_caller:
             fatal_error(msg)
         status = error.returncode
-    return status
+
+    if status_to_caller and output_to_caller:
+        ret_value = (status, output)
+    elif status_to_caller:
+        ret_value = status
+    elif output_to_caller:
+        ret_value = output
+    else:
+        ret_value = None
+
+    return ret_value
+
+
+def failed_command_msg(msg_context, command):
+    """Template for consistent error messages from subprocess calls.
+    """
+    error_msg = string.Template("""$context
+Failed command:
+    $command
+Please check the log file "$log" for more details.""")
+    values = {
+        'context': msg_context,
+        'command': ' '.join(command),
+        'log': LOG_FILE_NAME,
+    }
+    msg = error_msg.substitute(values)
+    return msg

--- a/manic/utils.py
+++ b/manic/utils.py
@@ -193,14 +193,19 @@ def execute_subprocess(commands, status_to_caller=False,
         logging.error(error)
         fatal_error(msg)
     except subprocess.CalledProcessError as error:
-        msg = failed_command_msg(
-            'Called process did not run successfully.\n'
-            'Returned status: {0}'.format(error.returncode),
-            commands)
-        logging.error(error)
-        logging.error(msg)
-        log_process_output(error.output)
+        # Only report the error if we are NOT returning to the
+        # caller. If we are returning to the caller, then it may be a
+        # simple status check. If returning, it is the callers
+        # responsibility determine if an error occurred and handle it
+        # appropriately.
         if not return_to_caller:
+            msg = failed_command_msg(
+                'Called process did not run successfully.\n'
+                'Returned status: {0}'.format(error.returncode),
+                commands)
+            logging.error(error)
+            logging.error(msg)
+            log_process_output(error.output)
             fatal_error(msg)
         status = error.returncode
 


### PR DESCRIPTION
* Break up the systems tests class into a base infrastructure class and several
test classes focused on testing specific conditions for checkout. Test classes
are focused on basic testing, svn testing, and error conditions.

* Add svn tests. If svn isn't available because of there is no executable or no
network connection, then the tests will be skipped. Moving forward skipped
tests should be reported...

* Consolidate the check_output and execute_subprocess into a single function.
Clean up error handling to prove more consistent and useful messages.

* The 'source' object was a remanent of the original xml input file naming.
Rename to External to clarify use.

* Rename some confusing variables and objects.

* Replace hard coded constants with variables.

* Replace multiple different uses of hard coded '.' strings with meaningfully
named constants.

User interface changes: None

Testing:
  python2/3 - make test including svn - pass
  python2 - manual cesm, clm checkout - ok

