### PR TITLE
Change config file metadata

### DIFF
--- a/manic/externals_description.py
+++ b/manic/externals_description.py
@@ -55,7 +55,7 @@ from .global_constants import EMPTY_STR, PPRINTER, VERSION_SEPERATOR
 # Globals
 #
 DESCRIPTION_SECTION = 'externals_description'
-VERSION_ITEM = 'version'
+VERSION_ITEM = 'schema_version'
 
 
 def read_externals_description_file(root_dir, file_name):


### PR DESCRIPTION
Change the 'version' key to 'schema_version' in the config file metadata. In
preparation for freezing 1.0 file format.

User interface changes?: Yes, backwards incompatible change to config file
format.

Testing:
    make test - pass, 1 skip - python2 and python3
    manual testing - cesm demo, clm demo, escomp/cesm - checkout/status - ok

