### PR TITLE
misc cleanup

### DIFF
--- a/manic/checkout.py
+++ b/manic/checkout.py
@@ -289,7 +289,6 @@ def main(args):
             printlog(msg)
             printlog('-' * 70)
         else:
-            printlog('Checkout components: ', end='')
             source_tree.checkout(load_all)
             printlog('')
 

--- a/manic/checkout.py
+++ b/manic/checkout.py
@@ -22,7 +22,7 @@ from manic.externals_description import read_externals_description_file
 from manic.externals_status import check_safe_to_update_repos
 from manic.sourcetree import SourceTree
 from manic.utils import printlog
-from manic.global_constants import PPRINTER, VERSION_SEPERATOR
+from manic.global_constants import VERSION_SEPERATOR
 
 if sys.hexversion < 0x02070000:
     print(70 * '*')
@@ -256,8 +256,6 @@ def main(args):
     root_dir = os.path.abspath(os.getcwd())
     external_data = read_externals_description_file(root_dir, args.externals)
     external = create_externals_description(external_data)
-    if args.debug:
-        PPRINTER.pprint(external)
 
     source_tree = SourceTree(root_dir, external)
     printlog('Checking status of components: ', end='')
@@ -274,7 +272,7 @@ def main(args):
             source_tree.verbose_status()
     else:
         # checkout / update the external repositories.
-        safe_to_update = check_safe_to_update_repos(tree_status, args.debug)
+        safe_to_update = check_safe_to_update_repos(tree_status)
         if not safe_to_update:
             # print status
             for comp in sorted(tree_status.keys()):

--- a/manic/externals_description.py
+++ b/manic/externals_description.py
@@ -71,7 +71,8 @@ def read_externals_description_file(root_dir, file_name):
     file_path = os.path.join(root_dir, file_name)
     if not os.path.exists(file_name):
         msg = ('ERROR: Model description file, "{0}", does not '
-               'exist at {1}'.format(file_name, file_path))
+               'exist at path:\n    {1}\nDid you run from the root of '
+               'the source tree?'.format(file_name, file_path))
         fatal_error(msg)
 
     externals_description = None

--- a/manic/externals_status.py
+++ b/manic/externals_status.py
@@ -9,7 +9,6 @@ from __future__ import unicode_literals
 from __future__ import print_function
 
 from .global_constants import EMPTY_STR
-from .utils import printlog
 
 
 class ExternalStatus(object):
@@ -109,7 +108,7 @@ class ExternalStatus(object):
         return exists
 
 
-def check_safe_to_update_repos(tree_status, debug):
+def check_safe_to_update_repos(tree_status):
     """Check if *ALL* repositories are in a safe state to update. We don't
     want to do a partial update of the repositories then die, leaving
     the model in an inconsistent state.
@@ -122,10 +121,6 @@ def check_safe_to_update_repos(tree_status, debug):
     safe_to_update = True
     for comp in tree_status:
         stat = tree_status[comp]
-        if debug:
-            printlog('{0} - {1} sync {2} clean {3}'.format(
-                comp, stat.safe_to_update(), stat.sync_state,
-                stat.clean_state))
-
         safe_to_update &= stat.safe_to_update()
+
     return safe_to_update

--- a/manic/sourcetree.py
+++ b/manic/sourcetree.py
@@ -6,7 +6,6 @@ FIXME(bja, 2017-11) External and SourceTree have a circular dependancy!
 import errno
 import logging
 import os
-import sys
 
 from .externals_description import ExternalsDescription
 from .externals_description import read_externals_description_file
@@ -174,6 +173,9 @@ class _External(object):
         if self._repo:
             self._repo.checkout(self._base_dir_path, self._repo_dir_name)
 
+    def checkout_externals(self, load_all):
+        """Checkout the sub-externals for this object
+        """
         if self._externals:
             if not self._externals_sourcetree:
                 self._create_externals_sourcetree()
@@ -275,6 +277,7 @@ class SourceTree(object):
         If load_all is False, load_comp is an optional set of components to load.
         If load_all is True and load_comp is None, only load the required externals.
         """
+        printlog('Checkout components: ', end='')
         if load_all:
             load_comps = self._all_components.keys()
         elif load_comp is not None:
@@ -282,7 +285,12 @@ class SourceTree(object):
         else:
             load_comps = self._required_compnames
 
+        # checkout the primary externals
         for comp in load_comps:
             printlog('{0}, '.format(comp), end='')
-            sys.stdout.flush()
             self._all_components[comp].checkout(load_all)
+        printlog('')
+
+        # now give each external an opportunitity to checkout it's externals.
+        for comp in load_comps:
+            self._all_components[comp].checkout_externals(load_all)


### PR DESCRIPTION
Misc cleanup:

* Convert recursive checkout from depth first to breadth first so externals and sub-externals info does not get mixed in screen output. GH-10

* Remove old debugging output.

* Update error message when configuration file can not be found to suggest user may not be in the root directory. GH-29

Closes: GH-10, GH-29

Testing:
    make test - pass, 1 skip, python2/3
    manual testing - ok - escomp/cesm, clm-demo - checkout, status, optional.