### PR TITLE
Update screen output.

### DIFF
--- a/manic/checkout.py
+++ b/manic/checkout.py
@@ -258,7 +258,7 @@ def main(args):
     external = create_externals_description(external_data)
 
     source_tree = SourceTree(root_dir, external)
-    printlog('Checking status of components: ', end='')
+    printlog('Checking status of externals: ', end='')
     tree_status = source_tree.status()
     printlog('')
 

--- a/manic/sourcetree.py
+++ b/manic/sourcetree.py
@@ -277,7 +277,7 @@ class SourceTree(object):
         If load_all is False, load_comp is an optional set of components to load.
         If load_all is True and load_comp is None, only load the required externals.
         """
-        printlog('Checkout components: ', end='')
+        printlog('Checking out externals: ', end='')
         if load_all:
             load_comps = self._all_components.keys()
         elif load_comp is not None:


### PR DESCRIPTION
Update the screen output for status and checkout to indicate externals instead
of components. During checkout step, change text from 'checkout' to action verb
'checking out'.

Addresses part of GH-43.

Testing:
  make test - pass with one skip, python2/3
  manual testing - clm python2 - ok

