### PR TITLE
Fix and add a bit of documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ The root of the source tree will be referred to as `${SRC_ROOT}` below.
 
   * tag (string) : tag to checkout
 
+    This can also be a git SHA-1
+
   * branch (string) : branch to checkout
 
     Note: either tag or branch must be supplied, but not both.

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ The root of the source tree will be referred to as `${SRC_ROOT}` below.
       * column three shows how the repository is managed, optional or required
 
     Colunm one will be one of these values:
-      * m : modified : repository is modefied compared to the externals description
+      * m : modified : repository is modified compared to the externals description
       * e : empty : directory does not exist - checkout_externals has not been run
       * ? : unknown : directory exists but .git or .svn directories are missing
 

--- a/manic/checkout.py
+++ b/manic/checkout.py
@@ -282,8 +282,10 @@ def main(args):
                 printlog(msg)
             # exit gracefully
             msg = textwrap.fill(
-                'Some external repositories are not in a clean '
-                'state. Please ensure all external repositories are clean '
+                'Some external repositories are not in a clean state. '
+                '(Generally, these are repositories with "M" in the '
+                'second column in the above status output.) '
+                'Please ensure all external repositories are clean '
                 'before updating.')
             printlog('-' * 70)
             printlog(msg)

--- a/manic/checkout.py
+++ b/manic/checkout.py
@@ -180,6 +180,8 @@ The root of the source tree will be referred to as `${SRC_ROOT}` below.
 
   * tag (string) : tag to checkout
 
+    This can also be a git SHA-1
+
   * branch (string) : branch to checkout
 
     Note: either tag or branch must be supplied, but not both.

--- a/manic/checkout.py
+++ b/manic/checkout.py
@@ -122,7 +122,7 @@ The root of the source tree will be referred to as `${SRC_ROOT}` below.
       * column three shows how the repository is managed, optional or required
 
     Colunm one will be one of these values:
-      * m : modified : repository is modefied compared to the externals description
+      * m : modified : repository is modified compared to the externals description
       * e : empty : directory does not exist - %(prog)s has not been run
       * ? : unknown : directory exists but .git or .svn directories are missing
 
@@ -282,7 +282,7 @@ def main(args):
                 printlog(msg)
             # exit gracefully
             msg = textwrap.fill(
-                'Some external repositories that are not in a clean '
+                'Some external repositories are not in a clean '
                 'state. Please ensure all external repositories are clean '
                 'before updating.')
             printlog('-' * 70)

--- a/manic/repository_git.py
+++ b/manic/repository_git.py
@@ -226,7 +226,7 @@ class GitRepository(Repository):
                 remote_name = self._determine_remote_name()
                 if not remote_name:
                     # git doesn't know about this remote. by definition
-                    # this is a modefied state.
+                    # this is a modified state.
                     stat.sync_state = ExternalStatus.MODEL_MODIFIED
                 else:
                     expected_ref = "{0}/{1}".format(remote_name, self._branch)


### PR DESCRIPTION
(1) Document that a 'tag' can also be a sha-1

It can be useful to point to a sha-1. This documents the ability to do so.

@bandre-ucar please confirm that this is the intended way to point to a sha-1 (i.e., via a "tag" line).

(2) When checkout_externals cannot run due to non-clean state, add a bit of information

I could never remember whether the problematic repos were ones with 'm' in the first column, or ones with 'M' in the second column, or both. I have added information documenting that the problem is generally 'M' in the second column.

(3) Fix some typos in documentation.