### PR TITLE
Fetch all tags from remote

### DIFF
--- a/manic/repository_git.py
+++ b/manic/repository_git.py
@@ -653,7 +653,7 @@ class GitRepository(Repository):
     def _git_fetch(remote_name):
         """Run the git fetch command to for the side effect of updating the repo
         """
-        cmd = ['git', 'fetch', remote_name]
+        cmd = ['git', 'fetch', '--tags', remote_name]
         execute_subprocess(cmd)
 
     @staticmethod


### PR DESCRIPTION
This is important if the externals file points to a tag that is not
contained in any branches on the remote.

User interface changes?: No

Fixes: #54 (New tags on git remote may not be fetched)
Testing:
  test removed: no
  unit tests: pass
  system tests: pass
  manual testing: pushed tag to remote, updated CESM.cfg to point to new tag,
  then ran checkout_externals

