### PR TITLE
Ignore untracked files when running checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ The root of the source tree will be referred to as `${SRC_ROOT}` below.
     If there are *any* modifications to *any* working copy according
     to the git or svn 'status' command, checkout_externals
     will not update any external repositories. Modifications
-    include: modified files, added files, removed files, missing
-    files or untracked files,
+    include: modified files, added files, removed files, or missing
+    files.
 
   * Checkout all required components from a user specified externals
     description file:

--- a/manic/checkout.py
+++ b/manic/checkout.py
@@ -93,8 +93,8 @@ The root of the source tree will be referred to as `${SRC_ROOT}` below.
     If there are *any* modifications to *any* working copy according
     to the git or svn 'status' command, %(prog)s
     will not update any external repositories. Modifications
-    include: modified files, added files, removed files, missing
-    files or untracked files,
+    include: modified files, added files, removed files, or missing
+    files.
 
   * Checkout all required components from a user specified externals
     description file:

--- a/manic/repository_git.py
+++ b/manic/repository_git.py
@@ -520,10 +520,12 @@ class GitRepository(Repository):
         * modified files
         * missing files
         * added files
-        * untracked files
         * removed
         * renamed
         * unmerged
+
+        Whether untracked files are considered depends on how the status
+        command was run (i.e., whether it was run with the '-u' option).
 
         NOTE: Based on the above definition, the porcelain status
         should be an empty string to be considered 'clean'. Of course
@@ -600,11 +602,13 @@ class GitRepository(Repository):
     def _git_status_porcelain_v1z():
         """Run git status to obtain repository information.
 
-        The machine parable format that is guarenteed not to change
+        This is run with '--untracked=no' to ignore untracked files.
+
+        The machine-portable format that is guaranteed not to change
         between git versions or *user configuration*.
 
         """
-        cmd = ['git', 'status', '--porcelain', '-z']
+        cmd = ['git', 'status', '--untracked-files=no', '--porcelain', '-z']
         git_output = execute_subprocess(cmd, output_to_caller=True)
         return git_output
 

--- a/manic/repository_svn.py
+++ b/manic/repository_svn.py
@@ -193,13 +193,15 @@ then rerun checkout_externals.
         * added files
         * deleted files
         * missing files
-        * unversioned files
 
-        The only acceptable state returned from svn is 'external'
+        Unversioned files do not affect the clean/dirty status.
+
+        'external' is also an acceptable state
 
         """
         # pylint: disable=invalid-name
         SVN_EXTERNAL = 'external'
+        SVN_UNVERSIONED = 'unversioned'
         # pylint: enable=invalid-name
 
         is_dirty = False
@@ -209,8 +211,13 @@ then rerun checkout_externals.
         for entry in entries:
             status = entry.find('./wc-status')
             item = status.get('item')
-            if item != SVN_EXTERNAL:
+            if item == SVN_EXTERNAL:
+                continue
+            if item == SVN_UNVERSIONED:
+                continue
+            else:
                 is_dirty = True
+                break
         return is_dirty
 
     # ----------------------------------------------------------------

--- a/test/test_unit_repository_git.py
+++ b/test/test_unit_repository_git.py
@@ -749,6 +749,7 @@ class TestGitRegExp(unittest.TestCase):
 class TestGitStatusPorcelain(unittest.TestCase):
     """Test parsing of output from git status --porcelain=v1 -z
     """
+    # pylint: disable=C0103
     GIT_STATUS_PORCELAIN_V1_ALL = (
         r' D INSTALL\0MM Makefile\0M README.md\0R  cmakelists.txt\0'
         r'CMakeLists.txt\0D  commit-message-template.txt\0A  stuff.txt\0'

--- a/test/test_unit_repository_svn.py
+++ b/test/test_unit_repository_svn.py
@@ -421,6 +421,13 @@ class TestSVNStatusXML(unittest.TestCase):
    props="none">
 </wc-status>
 </entry>
+<entry
+   path="junk.txt">
+<wc-status
+   item="unversioned"
+   props="none">
+</wc-status>
+</entry>
 </target>
 </status>'''
 
@@ -453,13 +460,14 @@ class TestSVNStatusXML(unittest.TestCase):
         self.assertTrue(is_dirty)
 
     def test_xml_status_dirty_unversion(self):
-        """Verify that svn status output is consindered dirty when there is a
-        unversioned file.
+        """Verify that svn status output ignores unversioned files when making
+        the clean/dirty decision.
+
         """
         svn_output = self.SVN_STATUS_XML_DIRTY_UNVERSION
         is_dirty = SvnRepository.xml_status_is_dirty(
             svn_output)
-        self.assertTrue(is_dirty)
+        self.assertFalse(is_dirty)
 
     def test_xml_status_dirty_added(self):
         """Verify that svn status output is consindered dirty when there is a
@@ -482,7 +490,7 @@ class TestSVNStatusXML(unittest.TestCase):
 
     def test_xml_status_dirty_clean(self):
         """Verify that svn status output is consindered clean when there are
-        no dirty files.
+        no 'dirty' files. This means accepting untracked and externals.
 
         """
         svn_output = self.SVN_STATUS_XML_CLEAN


### PR DESCRIPTION
Untracked files in a git or svn external have the potential to abort a checkout
and leave the sandbox in a poorly defined state that the user needs to resolve.
The initial implementation refused to update if untracked files were present to
prevent this. This restriction has been deamed too restrictive. It is possible
to request svn to do a dry-run and determine if a checkout or switch will be
successful. Git does not have a mechanism to determine if a checkout will be
successful before running, and there are not any clear workarounds.

For now untracked files are being ignored. If problems arise, restrictions and
checks will be re-added to address specific problems.

Closes: GH-51

Testing:
  new unit tests added for new git functionality
  existing tests were updated to test for new behavior.
  python2 - make test - all tests pass, one skip.
