### PR TITLE
add option to disable logging

### DIFF
--- a/checkout_externals
+++ b/checkout_externals
@@ -10,7 +10,6 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from __future__ import print_function
 
-import logging
 import sys
 import traceback
 
@@ -26,11 +25,6 @@ if sys.hexversion < 0x02070000:
 
 
 if __name__ == '__main__':
-    logging.basicConfig(filename=manic.global_constants.LOG_FILE_NAME,
-                        format='%(levelname)s : %(asctime)s : %(message)s',
-                        datefmt='%Y-%m-%d %H:%M:%S',
-                        level=logging.DEBUG)
-
     ARGS = manic.checkout.commandline_arguments()
     try:
         RET_STATUS, _ = manic.checkout.main(ARGS)

--- a/manic/checkout.py
+++ b/manic/checkout.py
@@ -22,7 +22,7 @@ from manic.externals_description import read_externals_description_file
 from manic.externals_status import check_safe_to_update_repos
 from manic.sourcetree import SourceTree
 from manic.utils import printlog
-from manic.global_constants import VERSION_SEPERATOR
+from manic.global_constants import VERSION_SEPERATOR, LOG_FILE_NAME
 
 if sys.hexversion < 0x02070000:
     print(70 * '*')
@@ -231,6 +231,9 @@ The root of the source tree will be referred to as `${SRC_ROOT}` below.
                         help='DEVELOPER: output additional debugging '
                         'information to the screen and log file.')
 
+    parser.add_argument('--no-logging', action='store_true',
+                        help='DEVELOPER: disable logging.')
+
     if args:
         options = parser.parse_args(args)
     else:
@@ -249,6 +252,12 @@ def main(args):
     Parse externals file and load required repositories or all repositories if
     the --all option is passed.
     """
+    if not args.no_logging:
+        logging.basicConfig(filename=LOG_FILE_NAME,
+                            format='%(levelname)s : %(asctime)s : %(message)s',
+                            datefmt='%Y-%m-%d %H:%M:%S',
+                            level=logging.DEBUG)
+
     logging.info('Begining of checkout_externals')
 
     load_all = False

--- a/test/Makefile
+++ b/test/Makefile
@@ -85,8 +85,11 @@ style : FORCE
 	$(AUTOPEP8) $(AUTOPEP8_ARGS) --recursive $(SRC) $(TEST_DIR)/test_*.py
 
 .PHONY : lint
-lint : style
+lint : FORCE
 	$(PYLINT) $(PYLINT_ARGS) $(SRC) $(TEST_DIR)/test_*.py
+
+.PHONY : stylint
+stylint : style lint
 
 .PHONY : coverage
 coverage : FORCE


### PR DESCRIPTION
Add command line option, --no-logging, to disable logging to a file. In this mode, debug and info level output from subprocess commands is dropped, and only warning, error and critical output is output to the screen.

Update makefile to remove style as a prereq for the lint command. When 'make lint' is run by CI, it will now return the actual lint status. Add new rule 'stylint' for running autopep8 and lint in one command.    

Closes: GH-47

Testing:
    make test - all tests pass, one test skipped
    manual testing - run with --no-logging, no log file written to disk. Error level log written to screen, info level dropped.
