### PR TITLE
Better error messages for failed commands

### DIFF
--- a/manic/repository_svn.py
+++ b/manic/repository_svn.py
@@ -142,9 +142,9 @@ in the new revision.
 
 To recover: Clean up the above directory (resolving conflicts, etc.),
 then rerun checkout_externals.
-""".format(cwd = repo_dir_path,
-           message = message,
-           status = status)
+""".format(cwd=repo_dir_path,
+                message=message,
+                status=status)
 
             fatal_error(errmsg)
 

--- a/manic/repository_svn.py
+++ b/manic/repository_svn.py
@@ -11,7 +11,7 @@ import xml.etree.ElementTree as ET
 
 from .repository import Repository
 from .externals_status import ExternalStatus
-from .utils import fatal_error, log_process_output
+from .utils import fatal_error, log_process_output, indent_string
 from .utils import execute_subprocess
 
 
@@ -69,6 +69,11 @@ class SvnRepository(Repository):
             cwd = os.getcwd()
             os.chdir(repo_dir_path)
             self._svn_switch(self._url)
+            # svn switch can lead to a conflict state, but it gives a
+            # return code of 0. So now we need to make sure that we're
+            # in a clean (non-conflict) state.
+            self._abort_if_dirty(repo_dir_path,
+                                 "Expected clean state following switch")
             os.chdir(cwd)
         else:
             self._svn_checkout(self._url, repo_dir_path)
@@ -111,6 +116,37 @@ class SvnRepository(Repository):
                 stat.sync_state = ExternalStatus.UNKNOWN
             else:
                 stat.sync_state = self._check_url(svn_output, self._url)
+
+    def _abort_if_dirty(self, repo_dir_path, message):
+        """Check if the repo is in a dirty state; if so, abort with a
+        helpful message.
+
+        """
+
+        stat = ExternalStatus()
+        self._status_summary(stat, repo_dir_path)
+        if stat.clean_state != ExternalStatus.STATUS_OK:
+            status = self._svn_status_verbose(repo_dir_path)
+            status = indent_string(status, 4)
+            errmsg = """In directory
+    {cwd}
+
+svn status now shows:
+{status}
+
+ERROR: {message}
+
+One possible cause of this problem is that there may have been untracked
+files in your working directory that had the same name as tracked files
+in the new revision.
+
+To recover: Clean up the above directory (resolving conflicts, etc.),
+then rerun checkout_externals.
+""".format(cwd = repo_dir_path,
+           message = message,
+           status = status)
+
+            fatal_error(errmsg)
 
     @staticmethod
     def _check_url(svn_output, expected_url):

--- a/manic/utils.py
+++ b/manic/utils.py
@@ -10,7 +10,6 @@ from __future__ import print_function
 
 import logging
 import os
-import string
 import subprocess
 import sys
 
@@ -47,6 +46,7 @@ def printlog(msg, **kwargs):
         print(msg)
     sys.stdout.flush()
 
+
 def last_n_lines(the_string, n_lines, truncation_message=None):
     """Returns the last n lines of the given string
 
@@ -72,6 +72,7 @@ def last_n_lines(the_string, n_lines, truncation_message=None):
             str_truncated = truncation_message + '\n' + str_truncated
         return str_truncated
 
+
 def indent_string(the_string, indent_level):
     """Indents the given string by a given number of spaces
 
@@ -81,12 +82,12 @@ def indent_string(the_string, indent_level):
 
     Returns a new string that is the same as the_string, except that
     each line is indented by 'indent_level' spaces.
-    
+
     In python3, this can be done with textwrap.indent.
     """
 
     lines = the_string.splitlines(True)
-    padding = ' '*indent_level
+    padding = ' ' * indent_level
     lines_indented = [padding + line for line in lines]
     return ''.join(lines_indented)
 
@@ -95,6 +96,8 @@ def indent_string(the_string, indent_level):
 # error handling
 #
 # ---------------------------------------------------------------------
+
+
 def fatal_error(message):
     """
     Error output function
@@ -246,7 +249,7 @@ def execute_subprocess(commands, status_to_caller=False,
             msg = failed_command_msg(
                 msg_context,
                 commands,
-                output = error.output)
+                output=error.output)
             logging.error(error)
             logging.error(msg)
             log_process_output(error.output)
@@ -274,7 +277,7 @@ def failed_command_msg(msg_context, command, output=None):
 
     if output:
         output_truncated = last_n_lines(output, 20,
-                                        truncation_message = '[... Output truncated for brevity ...]')
+                                        truncation_message='[... Output truncated for brevity ...]')
         errmsg = ('Failed with output:\n' +
                   indent_string(output_truncated, 4) +
                   '\nERROR: ')
@@ -286,11 +289,12 @@ def failed_command_msg(msg_context, command, output=None):
     {cwd}
 {context}:
     {command}
-""".format(cwd = os.getcwd(), context = msg_context, command = command_str)
+""".format(cwd=os.getcwd(), context=msg_context, command=command_str)
 
     if output:
         errmsg += 'See above for output from failed command.\n'
 
-    errmsg += 'Please check the log file {log} for more details.'.format(log = LOG_FILE_NAME)
+    errmsg += 'Please check the log file {log} for more details.'.format(
+        log=LOG_FILE_NAME)
 
     return errmsg

--- a/manic/utils.py
+++ b/manic/utils.py
@@ -58,8 +58,8 @@ def last_n_lines(the_string, n_lines, truncation_message=None):
     Returns a string containing the last n lines of the_string
 
     If truncation_message is provided, the returned string begins with
-    the given message if and only if the string is less than n lines to
-    begin with.
+    the given message if and only if the string is greater than n lines
+    to begin with.
     """
 
     lines = the_string.splitlines(True)

--- a/test/test_unit_utils.py
+++ b/test/test_unit_utils.py
@@ -14,6 +14,7 @@ from __future__ import print_function
 import os
 import unittest
 
+from manic.utils import last_n_lines, indent_string
 from manic.utils import str_to_bool, execute_subprocess
 from manic.utils import is_remote_url, split_remote_url, expand_local_url
 
@@ -49,6 +50,66 @@ class TestExecuteSubprocess(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             execute_subprocess(cmd, status_to_caller=False)
 
+class TestLastNLines(unittest.TestCase):
+    """Test the last_n_lines function.
+
+    """
+
+    def test_last_n_lines_short(self):
+        """With a message with <= n lines, result of last_n_lines should
+        just be the original message.
+
+        """
+        mystr = """three
+line
+string
+"""
+
+        mystr_truncated = last_n_lines(mystr, 3, truncation_message='[truncated]')
+        self.assertEqual(mystr, mystr_truncated)
+
+    def test_last_n_lines_long(self):
+        """With a message with > n lines, result of last_n_lines should
+        be a truncated string.
+
+        """
+        mystr = """a
+big
+five
+line
+string
+"""
+        expected = """[truncated]
+five
+line
+string
+"""
+
+        mystr_truncated = last_n_lines(mystr, 3, truncation_message='[truncated]')
+        self.assertEqual(expected, mystr_truncated)
+
+class TestIndentStr(unittest.TestCase):
+    """Test the indent_string function.
+
+    """
+
+    def test_indent_string_singleline(self):
+        mystr = 'foo'
+        result = indent_string(mystr, 4)
+        expected = '    foo'
+        self.assertEqual(expected, result)
+
+    def test_indent_string_multiline(self):
+        mystr = """hello
+hi
+goodbye
+"""
+        result = indent_string(mystr, 2)
+        expected = """  hello
+  hi
+  goodbye
+"""
+        self.assertEqual(expected, result)
 
 class TestStrToBool(unittest.TestCase):
     """Test the string to boolean conversion routine.

--- a/test/test_unit_utils.py
+++ b/test/test_unit_utils.py
@@ -50,6 +50,7 @@ class TestExecuteSubprocess(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             execute_subprocess(cmd, status_to_caller=False)
 
+
 class TestLastNLines(unittest.TestCase):
     """Test the last_n_lines function.
 
@@ -65,7 +66,8 @@ line
 string
 """
 
-        mystr_truncated = last_n_lines(mystr, 3, truncation_message='[truncated]')
+        mystr_truncated = last_n_lines(
+            mystr, 3, truncation_message='[truncated]')
         self.assertEqual(mystr, mystr_truncated)
 
     def test_last_n_lines_long(self):
@@ -85,8 +87,10 @@ line
 string
 """
 
-        mystr_truncated = last_n_lines(mystr, 3, truncation_message='[truncated]')
+        mystr_truncated = last_n_lines(
+            mystr, 3, truncation_message='[truncated]')
         self.assertEqual(expected, mystr_truncated)
+
 
 class TestIndentStr(unittest.TestCase):
     """Test the indent_string function.
@@ -94,12 +98,18 @@ class TestIndentStr(unittest.TestCase):
     """
 
     def test_indent_string_singleline(self):
+        """Test the indent_string function with a single-line string
+
+        """
         mystr = 'foo'
         result = indent_string(mystr, 4)
         expected = '    foo'
         self.assertEqual(expected, result)
 
     def test_indent_string_multiline(self):
+        """Test the indent_string function with a multi-line string
+
+        """
         mystr = """hello
 hi
 goodbye
@@ -110,6 +120,7 @@ goodbye
   goodbye
 """
         self.assertEqual(expected, result)
+
 
 class TestStrToBool(unittest.TestCase):
     """Test the string to boolean conversion routine.


### PR DESCRIPTION
Two related changes here:

1. For any failed command run via `execute_subprocess`, print more
   information about the problem to stdout

2. After doing an `svn switch`, check the status of the resulting
   repository; if dirty, abort with a helpful message

The immediate purpose of both of these is to give more helpful error
messages if there are failures due to the presence of untracked files,
now that we attempt a checkout even if there are untracked files (via
https://github.com/NCAR/manage_externals/pull/57). If there is an
untracked file in the working directory that would get overwritten by a
tracked file in the new version:

* git aborts the `checkout` with an error code; the new information
  printed by (1) will help users in this case

* svn attempts the `checkout` and returns a 0 error status, but may
  leave you in a conflict state; we check this via (2)

Note that (2) should never happen currently (due to the up-front
conservative check of the repository status, which doesn't even allow
untracked files), but it will become possible after
https://github.com/NCAR/manage_externals/pull/57.

User interface changes?: No

Testing:
  new unit tests added for some utility functions
  unit tests: pass
  system tests: pass
  manual testing: For both git and svn, tested having an untracked file
    in the working directory that gets overwritten after checking out a
    new branch; did this testing on top of the changes in
    https://github.com/NCAR/manage_externals/pull/57

Here is sample output when git refuses to do the checkout:

```
Processing externals description file : CESM.cfg
Checking status of externals: clm, mosart, ww3, cime, cice, pop, cism, rtm, cam, cime_config,
Checking out externals: clm, mosart, ww3, cime,
ERROR: Failed with output:
    error: The following untracked working tree files would be overwritten by checkout:
    	LICENSE.TXT
    Please move or remove them before you switch branches.
    Aborting

ERROR: In directory
    /Users/sacks/cesm_code/cesm/cime
Process did not run successfully; returned status 1:
    git checkout cime5.4.0-alpha.03
See above for output from failed command.
Please check the log file manage_externals.log for more details.
```

And for svn:

```
Processing externals description file : CESM.cfg
Checking status of externals: clm, mosart, ww3, cime, cice, pop, cism, rtm, cam, cime_config,
Checking out externals: clm,
ERROR: In directory
    /Users/sacks/cesm_code/cesm/components/clm

svn status now shows:
    X       /Users/sacks/cesm_code/cesm/components/clm/src/fates
    ?       /Users/sacks/cesm_code/cesm/components/clm/testfile
    X       /Users/sacks/cesm_code/cesm/components/clm/tools/PTCLM
    D     C /Users/sacks/cesm_code/cesm/components/clm/tools/mksurfdata_map/src/test/mkgridmap_test
          >   local dir unversioned, incoming dir add upon switch
    D       /Users/sacks/cesm_code/cesm/components/clm/tools/mksurfdata_map/src/test/mkgridmap_test/CMakeLists.txt
    D       /Users/sacks/cesm_code/cesm/components/clm/tools/mksurfdata_map/src/test/mkgridmap_test/test_mkgridmap.pf

    Performing status on external item at 'src/fates':

    Performing status on external item at 'tools/PTCLM':
    Summary of conflicts:
      Tree conflicts: 1


ERROR: Expected clean state following switch

One possible cause of this problem is that there may have been untracked
files in your working directory that had the same name as tracked files
in the new revision.

To recover: Clean up the above directory (resolving conflicts, etc.),
then rerun checkout_externals.
```
