### PR TITLE
Add option for increased output verbosity

### DIFF
--- a/manic/checkout.py
+++ b/manic/checkout.py
@@ -218,9 +218,9 @@ The root of the source tree will be referred to as `${SRC_ROOT}` below.
 
     parser.add_argument('-v', '--verbose', action='count', default=0,
                         help='Output additional information to '
-                        'the screen and log file. For --status, this flag '
-                        'can be used a second time, increasing the verbosity'
-                        'level each time.')
+                        'the screen and log file. This flag can be '
+                        'used up to two times, increasing the '
+                        'verbosity level each time.')
 
     #
     # developer options

--- a/manic/checkout.py
+++ b/manic/checkout.py
@@ -23,7 +23,6 @@ from manic.externals_status import check_safe_to_update_repos
 from manic.sourcetree import SourceTree
 from manic.utils import printlog
 from manic.global_constants import VERSION_SEPERATOR, LOG_FILE_NAME
-from manic.global_constants import VERBOSITY_DUMP
 
 if sys.hexversion < 0x02070000:
     print(70 * '*')
@@ -219,8 +218,9 @@ The root of the source tree will be referred to as `${SRC_ROOT}` below.
 
     parser.add_argument('-v', '--verbose', action='count', default=0,
                         help='Output additional information to '
-                        'the screen and log file. This flag can be used '
-                        'multiple times.')
+                        'the screen and log file. For --status, this flag '
+                        'can be used a second time, increasing the verbosity'
+                        'level each time.')
 
     #
     # developer options
@@ -277,12 +277,8 @@ def main(args):
 
     if args.status:
         # user requested status-only
-        if args.verbose != VERBOSITY_DUMP:
-            for comp in sorted(tree_status.keys()):
-                tree_status[comp].log_status_message(args.verbose)
-        else:  # args.verbose == VERBOSITY_DUMP
-            # user requested verbose status dump of the git/svn status commands
-            source_tree.verbose_status_dump()
+        for comp in sorted(tree_status.keys()):
+            tree_status[comp].log_status_message(args.verbose)
     else:
         # checkout / update the external repositories.
         safe_to_update = check_safe_to_update_repos(tree_status)

--- a/manic/checkout.py
+++ b/manic/checkout.py
@@ -280,7 +280,7 @@ def main(args):
             printlog(msg)
         if args.verbose:
             # user requested verbose status dump of the git/svn status commands
-            source_tree.verbose_status()
+            source_tree.verbose_status_dump()
     else:
         # checkout / update the external repositories.
         safe_to_update = check_safe_to_update_repos(tree_status)

--- a/manic/externals_status.py
+++ b/manic/externals_status.py
@@ -9,8 +9,8 @@ from __future__ import unicode_literals
 from __future__ import print_function
 
 from .global_constants import EMPTY_STR
-from .utils import printlog
-from .global_constants import VERBOSITY_DEFAULT
+from .utils import printlog, indent_string
+from .global_constants import VERBOSITY_VERBOSE, VERBOSITY_DUMP
 
 
 class ExternalStatus(object):
@@ -50,25 +50,26 @@ class ExternalStatus(object):
         self.path = EMPTY_STR
         self.current_version = EMPTY_STR
         self.expected_version = EMPTY_STR
+        self.status_output = EMPTY_STR
 
     def log_status_message(self, verbosity):
         """Write status message to the screen and log file
         """
-        if verbosity == VERBOSITY_DEFAULT:
-            msg = self.default_status_message()
-        else:
-            msg = self.verbose_status_message()
-        printlog(msg)
+        self._default_status_message()
+        if verbosity >= VERBOSITY_VERBOSE:
+            self._verbose_status_message()
+        if verbosity >= VERBOSITY_DUMP:
+            self._dump_status_message()
 
-    def default_status_message(self):
+    def _default_status_message(self):
         """Return the default terse status message string
         """
         msg = '{sync}{clean}{src_type} {path}'.format(
             sync=self.sync_state, clean=self.clean_state,
             src_type=self.source_type, path=self.path)
-        return msg
+        printlog(msg)
 
-    def verbose_status_message(self):
+    def _verbose_status_message(self):
         """Return the verbose status message string
         """
         clean_str = self.DEFAULT
@@ -81,9 +82,14 @@ class ExternalStatus(object):
         if self.sync_state != self.STATUS_OK:
             sync_str = '{current} --> {expected}'.format(
                 current=self.current_version, expected=self.expected_version)
-        msg = '{path} :\n    {clean}, {sync}'.format(
-            path=self.path, clean=clean_str, sync=sync_str)
-        return msg
+        msg = '        {clean}, {sync}'.format(clean=clean_str, sync=sync_str)
+        printlog(msg)
+
+    def _dump_status_message(self):
+        """Return the dump status message string
+        """
+        msg = indent_string(self.status_output, 12)
+        printlog(msg)
 
     def safe_to_update(self):
         """Report if it is safe to update a repository. Safe is defined as:

--- a/manic/externals_status.py
+++ b/manic/externals_status.py
@@ -9,6 +9,8 @@ from __future__ import unicode_literals
 from __future__ import print_function
 
 from .global_constants import EMPTY_STR
+from .utils import printlog
+from .global_constants import VERBOSITY_DEFAULT
 
 
 class ExternalStatus(object):
@@ -46,11 +48,41 @@ class ExternalStatus(object):
         self.clean_state = self.DEFAULT
         self.source_type = self.DEFAULT
         self.path = EMPTY_STR
+        self.current_version = EMPTY_STR
+        self.expected_version = EMPTY_STR
 
-    def __str__(self):
+    def log_status_message(self, verbosity):
+        """Write status message to the screen and log file
+        """
+        if verbosity == VERBOSITY_DEFAULT:
+            msg = self.default_status_message()
+        else:
+            msg = self.verbose_status_message()
+        printlog(msg)
+
+    def default_status_message(self):
+        """Return the default terse status message string
+        """
         msg = '{sync}{clean}{src_type} {path}'.format(
             sync=self.sync_state, clean=self.clean_state,
             src_type=self.source_type, path=self.path)
+        return msg
+
+    def verbose_status_message(self):
+        """Return the verbose status message string
+        """
+        clean_str = self.DEFAULT
+        if self.clean_state == self.STATUS_OK:
+            clean_str = 'clean sandbox'
+        elif self.clean_state == self.DIRTY:
+            clean_str = 'modified sandbox'
+
+        sync_str = 'on {0}'.format(self.current_version)
+        if self.sync_state != self.STATUS_OK:
+            sync_str = '{current} --> {expected}'.format(
+                current=self.current_version, expected=self.expected_version)
+        msg = '{path} :\n    {clean}, {sync}'.format(
+            path=self.path, clean=clean_str, sync=sync_str)
         return msg
 
     def safe_to_update(self):

--- a/manic/global_constants.py
+++ b/manic/global_constants.py
@@ -12,3 +12,7 @@ LOCAL_PATH_INDICATOR = '.'
 VERSION_SEPERATOR = '.'
 LOG_FILE_NAME = 'manage_externals.log'
 PPRINTER = pprint.PrettyPrinter(indent=4)
+
+VERBOSITY_DEFAULT = 0
+VERBOSITY_VERBOSE = 1
+VERBOSITY_DUMP = 2

--- a/manic/repository.py
+++ b/manic/repository.py
@@ -49,7 +49,7 @@ class Repository(object):
                'repository classes! {0}'.format(self.__class__.__name__))
         fatal_error(msg)
 
-    def verbose_status(self, repo_dir_path):  # pylint: disable=unused-argument
+    def verbose_status_dump(self, repo_dir_path):  # pylint: disable=unused-argument
         """Display the raw repo status to the user.
 
         """

--- a/manic/repository.py
+++ b/manic/repository.py
@@ -49,14 +49,6 @@ class Repository(object):
                'repository classes! {0}'.format(self.__class__.__name__))
         fatal_error(msg)
 
-    def verbose_status_dump(self, repo_dir_path):  # pylint: disable=unused-argument
-        """Display the raw repo status to the user.
-
-        """
-        msg = ('DEV_ERROR: status method must be implemented in all '
-               'repository classes! {0}'.format(self.__class__.__name__))
-        fatal_error(msg)
-
     def url(self):
         """Public access of repo url.
         """

--- a/manic/repository.py
+++ b/manic/repository.py
@@ -30,7 +30,7 @@ class Repository(object):
         if self._tag is not EMPTY_STR and self._branch is not EMPTY_STR:
             fatal_error('repo cannot have both a tag and a branch element')
 
-    def checkout(self, base_dir_path, repo_dir_name):  # pylint: disable=unused-argument
+    def checkout(self, base_dir_path, repo_dir_name, verbosity):  # pylint: disable=unused-argument
         """
         If the repo destination directory exists, ensure it is correct (from
         correct URL, correct branch or tag), and possibly update the source.

--- a/manic/repository_git.py
+++ b/manic/repository_git.py
@@ -10,10 +10,11 @@ import os
 import re
 
 from .global_constants import EMPTY_STR, LOCAL_PATH_INDICATOR
+from .global_constants import VERBOSITY_VERBOSE
 from .repository import Repository
 from .externals_status import ExternalStatus
 from .utils import expand_local_url, split_remote_url, is_remote_url
-from .utils import log_process_output, fatal_error
+from .utils import log_process_output, fatal_error, printlog
 from .utils import execute_subprocess
 
 
@@ -56,7 +57,7 @@ class GitRepository(Repository):
     # Public API, defined by Repository
     #
     # ----------------------------------------------------------------
-    def checkout(self, base_dir_path, repo_dir_name):
+    def checkout(self, base_dir_path, repo_dir_name, verbosity):
         """
         If the repo destination directory exists, ensure it is correct (from
         correct URL, correct branch or tag), and possibly update the source.
@@ -65,14 +66,14 @@ class GitRepository(Repository):
         """
         repo_dir_path = os.path.join(base_dir_path, repo_dir_name)
         if not os.path.exists(repo_dir_path):
-            self._clone_repo(base_dir_path, repo_dir_name)
-        self._checkout_ref(repo_dir_path)
+            self._clone_repo(base_dir_path, repo_dir_name, verbosity)
+        self._checkout_ref(repo_dir_path, verbosity)
 
     def status(self, stat, repo_dir_path):
         """
         If the repo destination directory exists, ensure it is correct (from
         correct URL, correct branch or tag), and possibly update the source.
-        If the repo destination directory does not exist, checkout the correce
+        If the repo destination directory does not exist, checkout the correct
         branch or tag.
         """
         self._check_sync(stat, repo_dir_path)
@@ -91,12 +92,12 @@ class GitRepository(Repository):
     # Internal work functions
     #
     # ----------------------------------------------------------------
-    def _clone_repo(self, base_dir_path, repo_dir_name):
+    def _clone_repo(self, base_dir_path, repo_dir_name, verbosity):
         """Prepare to execute the clone by managing directory location
         """
         cwd = os.getcwd()
         os.chdir(base_dir_path)
-        self._git_clone(self._url, repo_dir_name)
+        self._git_clone(self._url, repo_dir_name, verbosity)
         os.chdir(cwd)
 
     def _current_ref_from_branch_command(self, git_output):
@@ -163,6 +164,7 @@ class GitRepository(Repository):
                 current_ref = match.group(1)
             except BaseException:
                 msg = 'DEV_ERROR: regex to detect tracking branch failed.'
+                fatal_error(msg)
         else:
             # assumed local branch
             current_ref = ref.split()[1]
@@ -214,25 +216,31 @@ class GitRepository(Repository):
 
         cwd = os.getcwd()
         os.chdir(repo_dir_path)
+
         git_output = self._git_branch_vv()
         current_ref = self._current_ref_from_branch_command(git_output)
-        if current_ref == EMPTY_STR:
-            stat.sync_state = ExternalStatus.UNKNOWN
-        elif self._branch:
+
+        if self._branch:
             if self._url == LOCAL_PATH_INDICATOR:
                 expected_ref = self._branch
-                stat.sync_state = compare_refs(current_ref, expected_ref)
             else:
                 remote_name = self._determine_remote_name()
                 if not remote_name:
                     # git doesn't know about this remote. by definition
                     # this is a modified state.
-                    stat.sync_state = ExternalStatus.MODEL_MODIFIED
+                    expected_ref = "unknown_remote/{0}".format(self._branch)
                 else:
                     expected_ref = "{0}/{1}".format(remote_name, self._branch)
-                    stat.sync_state = compare_refs(current_ref, expected_ref)
         else:
-            stat.sync_state = compare_refs(current_ref, self._tag)
+            expected_ref = self._tag
+
+        stat.sync_state = compare_refs(current_ref, expected_ref)
+        if current_ref == EMPTY_STR:
+            stat.sync_state = ExternalStatus.UNKNOWN
+
+        stat.current_version = current_ref
+        stat.expected_version = expected_ref
+
         os.chdir(cwd)
 
     def _determine_remote_name(self):
@@ -305,19 +313,19 @@ class GitRepository(Repository):
         remote_name = "{0}_{1}".format(base_name, repo_name)
         return remote_name
 
-    def _checkout_ref(self, repo_dir):
+    def _checkout_ref(self, repo_dir, verbosity):
         """Checkout the user supplied reference
         """
         # import pdb; pdb.set_trace()
         cwd = os.getcwd()
         os.chdir(repo_dir)
         if self._url.strip() == LOCAL_PATH_INDICATOR:
-            self._checkout_local_ref()
+            self._checkout_local_ref(verbosity)
         else:
-            self._checkout_external_ref()
+            self._checkout_external_ref(verbosity)
         os.chdir(cwd)
 
-    def _checkout_local_ref(self):
+    def _checkout_local_ref(self, verbosity):
         """Checkout the reference considering the local repo only. Do not
         fetch any additional remotes or specify the remote when
         checkout out the ref.
@@ -328,9 +336,9 @@ class GitRepository(Repository):
         else:
             ref = self._branch
         self._check_for_valid_ref(ref)
-        self._git_checkout_ref(ref)
+        self._git_checkout_ref(ref, verbosity)
 
-    def _checkout_external_ref(self):
+    def _checkout_external_ref(self, verbosity):
         """Checkout the reference from a remote repository
         """
         remote_name = self._determine_remote_name()
@@ -348,7 +356,7 @@ class GitRepository(Repository):
             ref = self._tag
         else:
             ref = '{0}/{1}'.format(remote_name, self._branch)
-        self._git_checkout_ref(ref)
+        self._git_checkout_ref(ref, verbosity)
 
     def _check_for_valid_ref(self, ref):
         """Try some basic sanity checks on the user supplied reference so we
@@ -636,10 +644,12 @@ class GitRepository(Repository):
     #
     # ----------------------------------------------------------------
     @staticmethod
-    def _git_clone(url, repo_dir_name):
+    def _git_clone(url, repo_dir_name, verbosity):
         """Run git clone for the side effect of creating a repository.
         """
         cmd = ['git', 'clone', url, repo_dir_name]
+        if verbosity == VERBOSITY_VERBOSE:
+            printlog('    {0}'.format(' '.join(cmd)))
         execute_subprocess(cmd)
 
     @staticmethod
@@ -657,7 +667,7 @@ class GitRepository(Repository):
         execute_subprocess(cmd)
 
     @staticmethod
-    def _git_checkout_ref(ref):
+    def _git_checkout_ref(ref, verbosity):
         """Run the git checkout command to for the side effect of updating the repo
 
         Param: ref is a reference to a local or remote object in the
@@ -665,4 +675,6 @@ class GitRepository(Repository):
 
         """
         cmd = ['git', 'checkout', ref]
+        if verbosity == VERBOSITY_VERBOSE:
+            printlog('    {0}'.format(' '.join(cmd)))
         execute_subprocess(cmd)

--- a/manic/repository_git.py
+++ b/manic/repository_git.py
@@ -79,12 +79,12 @@ class GitRepository(Repository):
         if os.path.exists(repo_dir_path):
             self._status_summary(stat, repo_dir_path)
 
-    def verbose_status(self, repo_dir_path):
+    def verbose_status_dump(self, repo_dir_path):
         """Display the raw repo status to the user.
 
         """
         if os.path.exists(repo_dir_path):
-            self._status_verbose(repo_dir_path)
+            self._status_verbose_dump(repo_dir_path)
 
     # ----------------------------------------------------------------
     #
@@ -507,7 +507,7 @@ class GitRepository(Repository):
         else:
             stat.clean_state = ExternalStatus.STATUS_OK
 
-    def _status_verbose(self, repo_dir_path):
+    def _status_verbose_dump(self, repo_dir_path):
         """Display raw git status output to the user
 
         """

--- a/manic/repository_svn.py
+++ b/manic/repository_svn.py
@@ -12,7 +12,7 @@ import xml.etree.ElementTree as ET
 from .global_constants import EMPTY_STR, VERBOSITY_VERBOSE
 from .repository import Repository
 from .externals_status import ExternalStatus
-from .utils import fatal_error, log_process_output, indent_string, printlog
+from .utils import fatal_error, indent_string, printlog
 from .utils import execute_subprocess
 
 
@@ -86,13 +86,6 @@ class SvnRepository(Repository):
         self._check_sync(stat, repo_dir_path)
         if os.path.exists(repo_dir_path):
             self._status_summary(stat, repo_dir_path)
-
-    def verbose_status_dump(self, repo_dir_path):
-        """Display the raw repo status to the user.
-
-        """
-        if os.path.exists(repo_dir_path):
-            self._status_verbose_dump(repo_dir_path)
 
     # ----------------------------------------------------------------
     #
@@ -187,13 +180,9 @@ then rerun checkout_externals.
         else:
             stat.clean_state = ExternalStatus.STATUS_OK
 
-    def _status_verbose_dump(self, repo_dir_path):
-        """Display the raw svn status output to the user.
-
-        """
-        svn_output = self._svn_status_verbose(repo_dir_path)
-        log_process_output(svn_output)
-        print(svn_output)
+        # Now save the verbose status output incase the user wants to
+        # see it.
+        stat.status_output = self._svn_status_verbose(repo_dir_path)
 
     @staticmethod
     def xml_status_is_dirty(svn_output):
@@ -265,7 +254,7 @@ then rerun checkout_externals.
         Checkout a subversion repository (repo_url) to checkout_dir.
         """
         cmd = ['svn', 'checkout', url, repo_dir_path]
-        if verbosity == VERBOSITY_VERBOSE:
+        if verbosity >= VERBOSITY_VERBOSE:
             printlog('    {0}'.format(' '.join(cmd)))
         execute_subprocess(cmd)
 
@@ -275,6 +264,6 @@ then rerun checkout_externals.
         Switch branches for in an svn sandbox
         """
         cmd = ['svn', 'switch', url]
-        if verbosity == VERBOSITY_VERBOSE:
+        if verbosity >= VERBOSITY_VERBOSE:
             printlog('    {0}'.format(' '.join(cmd)))
         execute_subprocess(cmd)

--- a/manic/repository_svn.py
+++ b/manic/repository_svn.py
@@ -87,12 +87,12 @@ class SvnRepository(Repository):
             self._status_summary(stat, repo_dir_path)
         return stat
 
-    def verbose_status(self, repo_dir_path):
+    def verbose_status_dump(self, repo_dir_path):
         """Display the raw repo status to the user.
 
         """
         if os.path.exists(repo_dir_path):
-            self._status_verbose(repo_dir_path)
+            self._status_verbose_dump(repo_dir_path)
 
     # ----------------------------------------------------------------
     #
@@ -179,7 +179,7 @@ then rerun checkout_externals.
         else:
             stat.clean_state = ExternalStatus.STATUS_OK
 
-    def _status_verbose(self, repo_dir_path):
+    def _status_verbose_dump(self, repo_dir_path):
         """Display the raw svn status output to the user.
 
         """

--- a/manic/sourcetree.py
+++ b/manic/sourcetree.py
@@ -131,7 +131,7 @@ class _External(object):
 
         return all_stats
 
-    def verbose_status(self):
+    def verbose_status_dump(self):
         """Display the verbose status to the user. This is just the raw output
         from the repository 'status' command.
 
@@ -144,7 +144,7 @@ class _External(object):
             cwd = os.getcwd()
             os.chdir(self._repo_dir_path)
             if self._repo:
-                self._repo.verbose_status(self._repo_dir_path)
+                self._repo.verbose_status_dump(self._repo_dir_path)
             os.chdir(cwd)
 
     def checkout(self, load_all):
@@ -259,14 +259,14 @@ class SourceTree(object):
 
         return summary
 
-    def verbose_status(self):
+    def verbose_status_dump(self):
         """Display verbose status to the user. This is just the raw output of
         the git and svn status commands.
 
         """
         load_comps = self._all_components.keys()
         for comp in load_comps:
-            self._all_components[comp].verbose_status()
+            self._all_components[comp].verbose_status_dump()
 
     def checkout(self, load_all, load_comp=None):
         """

--- a/manic/sourcetree.py
+++ b/manic/sourcetree.py
@@ -173,8 +173,15 @@ class _External(object):
                 self._stat.log_status_message(VERBOSITY_VERBOSE)
 
         if self._repo:
+            if self._stat.sync_state == ExternalStatus.STATUS_OK:
+                # If we're already in sync, avoid showing verbose output
+                # from the checkout command, unless the verbosity level
+                # is 2 or more.
+                checkout_verbosity = verbosity - 1
+            else:
+                checkout_verbosity = verbosity
             self._repo.checkout(self._base_dir_path,
-                                self._repo_dir_name, verbosity)
+                                self._repo_dir_name, checkout_verbosity)
 
     def checkout_externals(self, verbosity, load_all):
         """Checkout the sub-externals for this object

--- a/test/test_sys_checkout.py
+++ b/test/test_sys_checkout.py
@@ -45,7 +45,7 @@ from manic.externals_description import DESCRIPTION_SECTION, VERSION_ITEM
 from manic.externals_status import ExternalStatus
 from manic.repository_git import GitRepository
 from manic.utils import printlog, execute_subprocess
-from manic.global_constants import LOCAL_PATH_INDICATOR
+from manic.global_constants import LOCAL_PATH_INDICATOR, VERBOSITY_DEFAULT
 from manic.global_constants import LOG_FILE_NAME
 from manic import checkout
 
@@ -492,7 +492,7 @@ class BaseTestSysCheckout(unittest.TestCase):
         dest_dir = os.path.join(os.environ[MANIC_TEST_TMP_REPO_ROOT],
                                 test_dir_name)
         # pylint: disable=W0212
-        GitRepository._git_clone(parent_repo_dir, dest_dir)
+        GitRepository._git_clone(parent_repo_dir, dest_dir, VERBOSITY_DEFAULT)
         return dest_dir
 
     @staticmethod

--- a/test/test_unit_repository_svn.py
+++ b/test/test_unit_repository_svn.py
@@ -84,16 +84,20 @@ class TestSvnRepositoryCheckURL(unittest.TestCase):
         """
         svn_output = SVN_INFO_MOSART
         expected_url = self._repo.url()
-        result = self._repo._check_url(svn_output, expected_url)
+        result, current_version = \
+            self._repo._check_url(svn_output, expected_url)
         self.assertEqual(result, ExternalStatus.STATUS_OK)
+        self.assertEqual(current_version, 'mosart/trunk_tags/mosart1_0_26')
 
     def test_check_url_different(self):
         """Test that we correctly reject an incorrect URL.
         """
         svn_output = SVN_INFO_CISM
         expected_url = self._repo.url()
-        result = self._repo._check_url(svn_output, expected_url)
+        result, current_version = \
+            self._repo._check_url(svn_output, expected_url)
         self.assertEqual(result, ExternalStatus.MODEL_MODIFIED)
+        self.assertEqual(current_version, 'glc/trunk_tags/cism2_1_37')
 
     def test_check_url_none(self):
         """Test that we can handle an empty string for output, e.g. not an svn
@@ -102,8 +106,10 @@ class TestSvnRepositoryCheckURL(unittest.TestCase):
         """
         svn_output = EMPTY_STR
         expected_url = self._repo.url()
-        result = self._repo._check_url(svn_output, expected_url)
+        result, current_version = \
+            self._repo._check_url(svn_output, expected_url)
         self.assertEqual(result, ExternalStatus.UNKNOWN)
+        self.assertEqual(current_version, '')
 
 
 class TestSvnRepositoryCheckSync(unittest.TestCase):


### PR DESCRIPTION
Implement the intermediate verbosity level for status and checkout.

User interface changes?: Yes
The command line arg '--verbose' can now be used 0, 1, or 2 times. Each time it is used increases the verbosity level of the output. The previous --verbose output is now obtained by using '--verbose --verbose'.

Fixes:
* GH-48 : provides additional information about what is checked out when running 'checkout_externals --status --verbose'
* GH-46, GH-49 : provides the git and svn commands being run via 'checkout_externals --verbose'

Testing:
  unit tests: python2 pass
  system tests: python2 pass, one skip
  manual testing: manually verified new output for cesm and standalone checkouts, empty, modified and out of sync output.

