### PR TITLE
Allow config file to point to a non-abbreviated hash

### DIFF
--- a/README_FIRST
+++ b/README_FIRST
@@ -1,3 +1,9 @@
+The master repository for manage_externals is
+https://github.com/NCAR/manage_externals. Any issues with this tool
+should be reported there.
+
+------------------------------------------------------------------------
+
 CESM is comprised of a number of different components that are
 developed and managed independently. Each component may have
 additional 'external' dependancies and optional parts that are also


### PR DESCRIPTION
Previously: If you pointed to a git hash, sometimes `checkout_externals`
said we're out-of-sync when really we're in-sync. This happens when the
abbreviated hash printed by `git branch --verbose --verbose`, (e.g.,
`(HEAD detached at cade91dfe)`) had a different number of characters
than the hash listed in the externals description file. This was a
problem if the full 40-character hash is listed in the externals
description file, or if the number of characters used in the
abbreviation in the externals description file differed from the number
of characters printed by git. Furthermore, running `checkout_externals`
to bring things in sync did not resolve this problem: it continued to
mark the given external as out-of-sync.

With this change, we call things in-sync if the full 40-character hash
is listed in the externals configuration file and we are in detached
head state with that hash checked out. (In contrast to what I suggested
in #68, the changes I implemented do NOT change behavior if
Externals.cfg lists a hash and we have a checked-out branch at that
hash: then it notes us as being out-of-sync and gets us into detached
head state at that hash, as it did before.)

User interface changes?: Yes
   Can now list a full (non-abbreviated) hash in the externals config
   file and be told that you're in sync.

   I have tested (both via the unit tests and manually) that it still
   works to list an abbreviated hash.

Fixes #68 (When pointing to a git hash, sometimes says out-of-sync when
          really in-sync)

Fixes #67 (Location of the manage_externals repository should be
          documented somewhere)

Testing:
  test removed: none
  unit tests: pass
  system tests: pass
  manual testing:
  - With abbreviated hash in externals file, says we're in sync if we
    are in detached head state with that hash checked out
  - With full 40-character hash in externals file, says we're in sync if
    we are in detached head state with that hash checked out
  - If we're in detached head state with the wrong hash checked out,
    says we're out-of-sync
