### PR TITLE
Bugfix: timeout limit for subprocesses

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,21 @@
 -- AUTOMATICALLY GENERATED FILE. DO NOT EDIT --
+
 [![Build Status](https://travis-ci.org/NCAR/manage_externals.svg?branch=master)](https://travis-ci.org/NCAR/manage_externals)[![Coverage Status](https://coveralls.io/repos/github/NCAR/manage_externals/badge.svg?branch=master)](https://coveralls.io/github/NCAR/manage_externals?branch=master)
 ```
 usage: checkout_externals [-h] [-e [EXTERNALS]] [-o] [-S] [-v] [--backtrace]
                           [-d] [--no-logging]
 
-checkout_externals manages checking out CESM externals from revision control
-based on a externals description file. By default only the required
-externals are checkout out.
+checkout_externals manages checking out groups of externals from revision
+control based on a externals description file. By default only the
+required externals are checkout out.
 
-NOTE: checkout_externals *MUST* be run from the root of the source tree.
+Operations performed by manage_externals utilities are explicit and
+data driven. checkout_externals will always make the working copy *exactly*
+match what is in the externals file when modifying the working copy of
+a repository.
+
+If checkout_externals isn't doing what you expected, double check the contents
+of the externals description file.
 
 Running checkout_externals without the '--status' option will always attempt to
 synchronize the working copy to exactly match the externals description.
@@ -36,18 +43,18 @@ optional arguments:
 
 ```
 NOTE: checkout_externals *MUST* be run from the root of the source tree it
-is managing. For example, if you cloned CLM with:
+is managing. For example, if you cloned a repository with:
 
-    $ git clone git@github.com/ncar/clm clm-dev
+    $ git clone git@github.com/{SOME_ORG}/some-project some-project-dev
 
-Then the root of the source tree is /path/to/clm-dev. If you obtained
-CLM via a checkout of CESM:
+Then the root of the source tree is /path/to/some-project-dev. If you
+obtained a sub-project via a checkout of another project:
 
-    $ git clone git@github.com/escomp/cesm cesm-dev
+    $ git clone git@github.com/{SOME_ORG}/some-project some-project-dev
 
-and you need to checkout the CLM externals, then the root of the
-source tree is /path/to/cesm-dev. Do *NOT* run checkout_externals
-from within /path/to/cesm-dev/components/clm.
+and you need to checkout the sub-project externals, then the root of the
+source tree is /path/to/some-project-dev. Do *NOT* run checkout_externals
+from within /path/to/some-project-dev/sub-project
 
 The root of the source tree will be referred to as `${SRC_ROOT}` below.
 
@@ -71,11 +78,14 @@ The root of the source tree will be referred to as `${SRC_ROOT}` below.
     include: modified files, added files, removed files, or missing
     files.
 
+    To avoid this safety check, edit the externals description file
+    and comment out the modified external block.
+
   * Checkout all required components from a user specified externals
     description file:
 
         $ cd ${SRC_ROOT}
-        $ ./manage_externals/checkout_externals --excernals myCESM.xml
+        $ ./manage_externals/checkout_externals --excernals my-externals.cfg
 
   * Status summary of the repositories managed by checkout_externals:
 
@@ -118,12 +128,17 @@ The root of the source tree will be referred to as `${SRC_ROOT}` below.
 # Externals description file
 
   The externals description contains a list of the external
-  repositories that are used and their version control locations. Each
-  external has:
+  repositories that are used and their version control locations. The
+  file format is the standard ini/cfg configuration file format. Each
+  external is defined by a section containing the component name in
+  square brackets:
 
-  * name (string) : component name, e.g. cime, cism, clm, cam, etc.
+  * name (string) : component name, e.g. [cime], [cism], etc.
 
-  * required (boolean) : whether the component is a required checkout
+  Each section has the following keyword-value pairs:
+
+  * required (boolean) : whether the component is a required checkout,
+    'true' or 'false'.
 
   * local_path (string) : component path *relative* to where
     checkout_externals is called.
@@ -132,10 +147,17 @@ The root of the source tree will be referred to as `${SRC_ROOT}` below.
     manage the component.  Valid values are 'git', 'svn',
     'externals_only'.
 
+    Switching an external between different protocols is not
+    supported, e.g. from svn to git. To switch protocols, you need to
+    manually move the old working copy to a new location.
+
     Note: 'externals_only' will only process the external's own
     external description file without trying to manage a repository
     for the component. This is used for retreiving externals for
-    standalone components like cam and clm.
+    standalone components like cam and clm. If the source root of the
+    externals_only component is the same as the main source root, then
+    the local path must be set to '.', the unix current working
+    directory, e. g. 'local_path = .'
 
   * repo_url (string) : URL for the repository location, examples:
     * https://svn-ccsm-models.cgd.ucar.edu/glc
@@ -162,7 +184,10 @@ The root of the source tree will be referred to as `${SRC_ROOT}` below.
 
     This can also be a git SHA-1
 
-  * branch (string) : branch to checkout
+  * branch (string) : branch to checkout from the specified
+    repository. Specifying a branch on a remote repository means that
+    checkout_externals will checkout the version of the branch in the remote,
+    not the the version in the local repository (if it exists).
 
     Note: either tag or branch must be supplied, but not both.
 
@@ -175,3 +200,5 @@ The root of the source tree will be referred to as `${SRC_ROOT}` below.
     externals description file pointed 'useful_library/sub-xternals.cfg',
     Then the main 'externals' field in the top level repo should point to
     'sub-externals.cfg'.
+
+  * Lines begining with '#' or ';' are comments and will be ignored.

--- a/manic/checkout.py
+++ b/manic/checkout.py
@@ -46,11 +46,18 @@ def commandline_arguments(args=None):
     Returns: processed command line arguments
     """
     description = '''
-%(prog)s manages checking out CESM externals from revision control
-based on a externals description file. By default only the required
-externals are checkout out.
 
-NOTE: %(prog)s *MUST* be run from the root of the source tree.
+%(prog)s manages checking out groups of externals from revision
+control based on a externals description file. By default only the
+required externals are checkout out.
+
+Operations performed by manage_externals utilities are explicit and
+data driven. %(prog)s will always make the working copy *exactly*
+match what is in the externals file when modifying the working copy of
+a repository.
+
+If %(prog)s isn't doing what you expected, double check the contents
+of the externals description file.
 
 Running %(prog)s without the '--status' option will always attempt to
 synchronize the working copy to exactly match the externals description.
@@ -59,18 +66,18 @@ synchronize the working copy to exactly match the externals description.
     epilog = '''
 ```
 NOTE: %(prog)s *MUST* be run from the root of the source tree it
-is managing. For example, if you cloned CLM with:
+is managing. For example, if you cloned a repository with:
 
-    $ git clone git@github.com/ncar/clm clm-dev
+    $ git clone git@github.com/{SOME_ORG}/some-project some-project-dev
 
-Then the root of the source tree is /path/to/clm-dev. If you obtained
-CLM via a checkout of CESM:
+Then the root of the source tree is /path/to/some-project-dev. If you
+obtained a sub-project via a checkout of another project:
 
-    $ git clone git@github.com/escomp/cesm cesm-dev
+    $ git clone git@github.com/{SOME_ORG}/some-project some-project-dev
 
-and you need to checkout the CLM externals, then the root of the
-source tree is /path/to/cesm-dev. Do *NOT* run %(prog)s
-from within /path/to/cesm-dev/components/clm.
+and you need to checkout the sub-project externals, then the root of the
+source tree is /path/to/some-project-dev. Do *NOT* run %(prog)s
+from within /path/to/some-project-dev/sub-project
 
 The root of the source tree will be referred to as `${SRC_ROOT}` below.
 
@@ -95,11 +102,14 @@ The root of the source tree will be referred to as `${SRC_ROOT}` below.
     include: modified files, added files, removed files, or missing
     files.
 
+    To avoid this safety check, edit the externals description file
+    and comment out the modified external block.
+
   * Checkout all required components from a user specified externals
     description file:
 
         $ cd ${SRC_ROOT}
-        $ ./manage_externals/%(prog)s --excernals myCESM.xml
+        $ ./manage_externals/%(prog)s --excernals my-externals.cfg
 
   * Status summary of the repositories managed by %(prog)s:
 
@@ -143,12 +153,17 @@ The root of the source tree will be referred to as `${SRC_ROOT}` below.
 # Externals description file
 
   The externals description contains a list of the external
-  repositories that are used and their version control locations. Each
-  external has:
+  repositories that are used and their version control locations. The
+  file format is the standard ini/cfg configuration file format. Each
+  external is defined by a section containing the component name in
+  square brackets:
 
-  * name (string) : component name, e.g. cime, cism, clm, cam, etc.
+  * name (string) : component name, e.g. [cime], [cism], etc.
 
-  * required (boolean) : whether the component is a required checkout
+  Each section has the following keyword-value pairs:
+
+  * required (boolean) : whether the component is a required checkout,
+    'true' or 'false'.
 
   * local_path (string) : component path *relative* to where
     %(prog)s is called.
@@ -157,10 +172,17 @@ The root of the source tree will be referred to as `${SRC_ROOT}` below.
     manage the component.  Valid values are 'git', 'svn',
     'externals_only'.
 
+    Switching an external between different protocols is not
+    supported, e.g. from svn to git. To switch protocols, you need to
+    manually move the old working copy to a new location.
+
     Note: 'externals_only' will only process the external's own
     external description file without trying to manage a repository
     for the component. This is used for retreiving externals for
-    standalone components like cam and clm.
+    standalone components like cam and clm. If the source root of the
+    externals_only component is the same as the main source root, then
+    the local path must be set to '.', the unix current working
+    directory, e. g. 'local_path = .'
 
   * repo_url (string) : URL for the repository location, examples:
     * https://svn-ccsm-models.cgd.ucar.edu/glc
@@ -187,7 +209,10 @@ The root of the source tree will be referred to as `${SRC_ROOT}` below.
 
     This can also be a git SHA-1
 
-  * branch (string) : branch to checkout
+  * branch (string) : branch to checkout from the specified
+    repository. Specifying a branch on a remote repository means that
+    %(prog)s will checkout the version of the branch in the remote,
+    not the the version in the local repository (if it exists).
 
     Note: either tag or branch must be supplied, but not both.
 
@@ -200,6 +225,8 @@ The root of the source tree will be referred to as `${SRC_ROOT}` below.
     externals description file pointed 'useful_library/sub-xternals.cfg',
     Then the main 'externals' field in the top level repo should point to
     'sub-externals.cfg'.
+
+  * Lines begining with '#' or ';' are comments and will be ignored.
 
 '''
 

--- a/manic/utils.py
+++ b/manic/utils.py
@@ -12,6 +12,7 @@ import logging
 import os
 import subprocess
 import sys
+import time
 
 from .global_constants import LOCAL_PATH_INDICATOR, LOG_FILE_NAME
 
@@ -198,6 +199,82 @@ def expand_local_url(url, field):
 # subprocess
 #
 # ---------------------------------------------------------------------
+_TIMEOUT_MSG = """ Timout errors typically occur when svn or git requires
+authentication to access a private repository. On some systems, svn
+and git requests for authentication information will not be displayed
+to the user.  In this case, the program will appear to hang and
+generate a timeout error. Ensure you can run svn and git manually and
+access all repositories without entering your authentication
+information."""
+
+_TIMEOUT_SEC = 300
+_POLL_DELTA_SEC = 0.02
+
+
+def _poll_subprocess(commands, status_to_caller, output_to_caller,
+                     timeout_sec=_TIMEOUT_SEC):
+    """Create a subprocess and poll the process until complete.
+
+    Impose a timeout limit and checkout process output for known
+    conditions that require user interaction.
+
+    NOTE: the timeout_delta has significant impact on run time. If it
+    is too long, and the many quick local subprocess calls will
+    drastically increase the run time, especially in tests.
+
+    NOTE: This function is broken out into for ease of
+    understanding. It does no error checking. It should only be called
+    from execute_subprocess, never directly.
+
+    """
+    logging.info(' '.join(commands))
+    output = []
+    start = time.time()
+
+    proc = subprocess.Popen(commands,
+                            shell=False,
+                            stdout=subprocess.PIPE,
+                            stderr=subprocess.STDOUT,
+                            universal_newlines=True)
+    while proc.poll() is None:
+        time.sleep(_POLL_DELTA_SEC)
+        if time.time() - start > timeout_sec:
+            proc.kill()
+            time.sleep(_POLL_DELTA_SEC * 5)
+            msg = ("subprocess call to  '{0}' has exceeded timeout limit of "
+                   "{1} seconds.\n{2}".format(commands[0], timeout_sec,
+                                              _TIMEOUT_MSG))
+            fatal_error(msg)
+    finish = time.time()
+
+    run_time_msg = "run time : {0:.2f} seconds".format(finish - start)
+    logging.info(run_time_msg)
+    output = proc.stdout.read()
+    log_process_output(output)
+    status = proc.returncode
+
+    # NOTE(bja, 2018-03) need to cleanup open files. In python3 use
+    # "with subprocess.Popen(...) as proc:", but that is not available
+    # with python2 unless we create a context manager.
+    proc.stdout.close()
+
+    if status != 0:
+        raise subprocess.CalledProcessError(returncode=status,
+                                            cmd=commands,
+                                            output=output)
+
+    if status_to_caller and output_to_caller:
+        ret_value = (status, output)
+    elif status_to_caller:
+        ret_value = status
+    elif output_to_caller:
+        ret_value = output
+    else:
+        ret_value = None
+
+    return ret_value
+
+
 def execute_subprocess(commands, status_to_caller=False,
                        output_to_caller=False):
     """Wrapper around subprocess.check_output to handle common
@@ -211,20 +288,30 @@ def execute_subprocess(commands, status_to_caller=False,
     return code, otherwise execute_subprocess treats non-zero return
     status as an error and raises an exception.
 
+    NOTE(bja, 2018-03) if the user doesn't have credentials setup
+    correctly, then svn and git will prompt for a username/password or
+    accepting the domain as trusted. We need to detect this and print
+    enough info for the user to determine what happened and enter the
+    appropriate information. When we detect some pre-determined
+    conditions, we turn on screen output so the user can see what is
+    needed. There doesn't appear to be a way to detect if the user
+    entered any information in the terminal. So there is no way to
+    turn off output.
+
+    NOTE(bja, 2018-03) we are polling the running process to avoid
+    having it hang indefinitely if there is input that we don't
+    detect. Some large checkouts are multiple minutes long. For now we
+    are setting the timeout interval to five minutes.
+
     """
     msg = 'In directory: {0}\nexecute_subprocess running command:'.format(
         os.getcwd())
     logging.info(msg)
     logging.info(commands)
     return_to_caller = status_to_caller or output_to_caller
-    status = -1
-    output = ''
     try:
-        logging.info(' '.join(commands))
-        output = subprocess.check_output(commands, stderr=subprocess.STDOUT,
-                                         universal_newlines=True)
-        log_process_output(output)
-        status = 0
+        ret_value = _poll_subprocess(
+            commands, status_to_caller, output_to_caller)
     except OSError as error:
         msg = failed_command_msg(
             'Command execution failed. Does the executable exist?',
@@ -246,24 +333,12 @@ def execute_subprocess(commands, status_to_caller=False,
         if not return_to_caller:
             msg_context = ('Process did not run successfully; '
                            'returned status {0}'.format(error.returncode))
-            msg = failed_command_msg(
-                msg_context,
-                commands,
-                output=error.output)
+            msg = failed_command_msg(msg_context, commands,
+                                     output=error.output)
             logging.error(error)
-            logging.error(msg)
             log_process_output(error.output)
             fatal_error(msg)
-        status = error.returncode
-
-    if status_to_caller and output_to_caller:
-        ret_value = (status, output)
-    elif status_to_caller:
-        ret_value = status
-    elif output_to_caller:
-        ret_value = output
-    else:
-        ret_value = None
+        ret_value = error.returncode
 
     return ret_value
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -71,7 +71,7 @@ test : utest stest
 #
 .PHONY : readme
 readme : $(CHECKOUT_EXE)
-	printf "%s\n" "-- AUTOMATICALLY GENERATED FILE. DO NOT EDIT --" > $(README)
+	printf "%s\n\n" "-- AUTOMATICALLY GENERATED FILE. DO NOT EDIT --" > $(README)
 	printf "%s" '[![Build Status](https://travis-ci.org/NCAR/manage_externals.svg?branch=master)](https://travis-ci.org/NCAR/manage_externals)' >> $(README)
 	printf "%s" '[![Coverage Status](https://coveralls.io/repos/github/NCAR/manage_externals/badge.svg?branch=master)](https://coveralls.io/github/NCAR/manage_externals?branch=master)' >> $(README)
 	printf "\n%s\n" '```' >> $(README)


### PR DESCRIPTION
    For security reasons svn and git do not use standard in/out/error to request
    and process authentication. Instead, they use lower level system interfaces.
    Python calling a subprocess can only interact with stdio, and can not intercept
    or detect the lower level calls. On some systems, these requests are visible
    to the user, on some systems they are not. When subprocess commands expect user
    input they will wait and manage_externals appears to hang.
    
    Change the subprocess calls to polling the running process and checking the
    current run time. If the run time exceeds a timeout limit, then we display an
    error message suggesting that the user verify authentication and then declare a
    fatal error.
    
    The default timeout interval of 5 minutes is probably too long and can be
    shortened. But since svn requires network interaction and some large checkouts
    can take a long time, this is a 'conservative' initial value.

    Breakup up the subprocess call routine so it is easier to understand.

Testing:
  make test - python3 - all tests pass.
  manually test without credentials to trigger new behavior - ok.

Addresses: GH-79