### PR TITLE
Update readme and help output

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,21 @@
 -- AUTOMATICALLY GENERATED FILE. DO NOT EDIT --
+
 [![Build Status](https://travis-ci.org/NCAR/manage_externals.svg?branch=master)](https://travis-ci.org/NCAR/manage_externals)[![Coverage Status](https://coveralls.io/repos/github/NCAR/manage_externals/badge.svg?branch=master)](https://coveralls.io/github/NCAR/manage_externals?branch=master)
 ```
 usage: checkout_externals [-h] [-e [EXTERNALS]] [-o] [-S] [-v] [--backtrace]
                           [-d] [--no-logging]
 
-checkout_externals manages checking out CESM externals from revision control
-based on a externals description file. By default only the required
-externals are checkout out.
+checkout_externals manages checking out groups of externals from revision
+control based on a externals description file. By default only the
+required externals are checkout out.
 
-NOTE: checkout_externals *MUST* be run from the root of the source tree.
+Operations performed by manage_externals utilities are explicit and
+data driven. checkout_externals will always make the working copy *exactly*
+match what is in the externals file when modifying the working copy of
+a repository.
+
+If checkout_externals isn't doing what you expected, double check the contents
+of the externals description file.
 
 Running checkout_externals without the '--status' option will always attempt to
 synchronize the working copy to exactly match the externals description.
@@ -36,18 +43,18 @@ optional arguments:
 
 ```
 NOTE: checkout_externals *MUST* be run from the root of the source tree it
-is managing. For example, if you cloned CLM with:
+is managing. For example, if you cloned a repository with:
 
-    $ git clone git@github.com/ncar/clm clm-dev
+    $ git clone git@github.com/{SOME_ORG}/some-project some-project-dev
 
-Then the root of the source tree is /path/to/clm-dev. If you obtained
-CLM via a checkout of CESM:
+Then the root of the source tree is /path/to/some-project-dev. If you
+obtained a sub-project via a checkout of another project:
 
-    $ git clone git@github.com/escomp/cesm cesm-dev
+    $ git clone git@github.com/{SOME_ORG}/some-project some-project-dev
 
-and you need to checkout the CLM externals, then the root of the
-source tree is /path/to/cesm-dev. Do *NOT* run checkout_externals
-from within /path/to/cesm-dev/components/clm.
+and you need to checkout the sub-project externals, then the root of the
+source tree is /path/to/some-project-dev. Do *NOT* run checkout_externals
+from within /path/to/some-project-dev/sub-project
 
 The root of the source tree will be referred to as `${SRC_ROOT}` below.
 
@@ -71,11 +78,14 @@ The root of the source tree will be referred to as `${SRC_ROOT}` below.
     include: modified files, added files, removed files, or missing
     files.
 
+    To avoid this safety check, edit the externals description file
+    and comment out the modified external block.
+
   * Checkout all required components from a user specified externals
     description file:
 
         $ cd ${SRC_ROOT}
-        $ ./manage_externals/checkout_externals --excernals myCESM.xml
+        $ ./manage_externals/checkout_externals --excernals my-externals.cfg
 
   * Status summary of the repositories managed by checkout_externals:
 
@@ -118,12 +128,17 @@ The root of the source tree will be referred to as `${SRC_ROOT}` below.
 # Externals description file
 
   The externals description contains a list of the external
-  repositories that are used and their version control locations. Each
-  external has:
+  repositories that are used and their version control locations. The
+  file format is the standard ini/cfg configuration file format. Each
+  external is defined by a section containing the component name in
+  square brackets:
 
-  * name (string) : component name, e.g. cime, cism, clm, cam, etc.
+  * name (string) : component name, e.g. [cime], [cism], etc.
 
-  * required (boolean) : whether the component is a required checkout
+  Each section has the following keyword-value pairs:
+
+  * required (boolean) : whether the component is a required checkout,
+    'true' or 'false'.
 
   * local_path (string) : component path *relative* to where
     checkout_externals is called.
@@ -132,10 +147,17 @@ The root of the source tree will be referred to as `${SRC_ROOT}` below.
     manage the component.  Valid values are 'git', 'svn',
     'externals_only'.
 
+    Switching an external between different protocols is not
+    supported, e.g. from svn to git. To switch protocols, you need to
+    manually move the old working copy to a new location.
+
     Note: 'externals_only' will only process the external's own
     external description file without trying to manage a repository
     for the component. This is used for retreiving externals for
-    standalone components like cam and clm.
+    standalone components like cam and clm. If the source root of the
+    externals_only component is the same as the main source root, then
+    the local path must be set to '.', the unix current working
+    directory, e. g. 'local_path = .'
 
   * repo_url (string) : URL for the repository location, examples:
     * https://svn-ccsm-models.cgd.ucar.edu/glc
@@ -162,7 +184,10 @@ The root of the source tree will be referred to as `${SRC_ROOT}` below.
 
     This can also be a git SHA-1
 
-  * branch (string) : branch to checkout
+  * branch (string) : branch to checkout from the specified
+    repository. Specifying a branch on a remote repository means that
+    checkout_externals will checkout the version of the branch in the remote,
+    not the the version in the local repository (if it exists).
 
     Note: either tag or branch must be supplied, but not both.
 
@@ -175,3 +200,5 @@ The root of the source tree will be referred to as `${SRC_ROOT}` below.
     externals description file pointed 'useful_library/sub-xternals.cfg',
     Then the main 'externals' field in the top level repo should point to
     'sub-externals.cfg'.
+
+  * Lines begining with '#' or ';' are comments and will be ignored.

--- a/manic/checkout.py
+++ b/manic/checkout.py
@@ -46,11 +46,18 @@ def commandline_arguments(args=None):
     Returns: processed command line arguments
     """
     description = '''
-%(prog)s manages checking out CESM externals from revision control
-based on a externals description file. By default only the required
-externals are checkout out.
 
-NOTE: %(prog)s *MUST* be run from the root of the source tree.
+%(prog)s manages checking out groups of externals from revision
+control based on a externals description file. By default only the
+required externals are checkout out.
+
+Operations performed by manage_externals utilities are explicit and
+data driven. %(prog)s will always make the working copy *exactly*
+match what is in the externals file when modifying the working copy of
+a repository.
+
+If %(prog)s isn't doing what you expected, double check the contents
+of the externals description file.
 
 Running %(prog)s without the '--status' option will always attempt to
 synchronize the working copy to exactly match the externals description.
@@ -59,18 +66,18 @@ synchronize the working copy to exactly match the externals description.
     epilog = '''
 ```
 NOTE: %(prog)s *MUST* be run from the root of the source tree it
-is managing. For example, if you cloned CLM with:
+is managing. For example, if you cloned a repository with:
 
-    $ git clone git@github.com/ncar/clm clm-dev
+    $ git clone git@github.com/{SOME_ORG}/some-project some-project-dev
 
-Then the root of the source tree is /path/to/clm-dev. If you obtained
-CLM via a checkout of CESM:
+Then the root of the source tree is /path/to/some-project-dev. If you
+obtained a sub-project via a checkout of another project:
 
-    $ git clone git@github.com/escomp/cesm cesm-dev
+    $ git clone git@github.com/{SOME_ORG}/some-project some-project-dev
 
-and you need to checkout the CLM externals, then the root of the
-source tree is /path/to/cesm-dev. Do *NOT* run %(prog)s
-from within /path/to/cesm-dev/components/clm.
+and you need to checkout the sub-project externals, then the root of the
+source tree is /path/to/some-project-dev. Do *NOT* run %(prog)s
+from within /path/to/some-project-dev/sub-project
 
 The root of the source tree will be referred to as `${SRC_ROOT}` below.
 
@@ -95,11 +102,14 @@ The root of the source tree will be referred to as `${SRC_ROOT}` below.
     include: modified files, added files, removed files, or missing
     files.
 
+    To avoid this safety check, edit the externals description file
+    and comment out the modified external block.
+
   * Checkout all required components from a user specified externals
     description file:
 
         $ cd ${SRC_ROOT}
-        $ ./manage_externals/%(prog)s --excernals myCESM.xml
+        $ ./manage_externals/%(prog)s --excernals my-externals.cfg
 
   * Status summary of the repositories managed by %(prog)s:
 
@@ -143,12 +153,17 @@ The root of the source tree will be referred to as `${SRC_ROOT}` below.
 # Externals description file
 
   The externals description contains a list of the external
-  repositories that are used and their version control locations. Each
-  external has:
+  repositories that are used and their version control locations. The
+  file format is the standard ini/cfg configuration file format. Each
+  external is defined by a section containing the component name in
+  square brackets:
 
-  * name (string) : component name, e.g. cime, cism, clm, cam, etc.
+  * name (string) : component name, e.g. [cime], [cism], etc.
 
-  * required (boolean) : whether the component is a required checkout
+  Each section has the following keyword-value pairs:
+
+  * required (boolean) : whether the component is a required checkout,
+    'true' or 'false'.
 
   * local_path (string) : component path *relative* to where
     %(prog)s is called.
@@ -157,10 +172,17 @@ The root of the source tree will be referred to as `${SRC_ROOT}` below.
     manage the component.  Valid values are 'git', 'svn',
     'externals_only'.
 
+    Switching an external between different protocols is not
+    supported, e.g. from svn to git. To switch protocols, you need to
+    manually move the old working copy to a new location.
+
     Note: 'externals_only' will only process the external's own
     external description file without trying to manage a repository
     for the component. This is used for retreiving externals for
-    standalone components like cam and clm.
+    standalone components like cam and clm. If the source root of the
+    externals_only component is the same as the main source root, then
+    the local path must be set to '.', the unix current working
+    directory, e. g. 'local_path = .'
 
   * repo_url (string) : URL for the repository location, examples:
     * https://svn-ccsm-models.cgd.ucar.edu/glc
@@ -187,7 +209,10 @@ The root of the source tree will be referred to as `${SRC_ROOT}` below.
 
     This can also be a git SHA-1
 
-  * branch (string) : branch to checkout
+  * branch (string) : branch to checkout from the specified
+    repository. Specifying a branch on a remote repository means that
+    %(prog)s will checkout the version of the branch in the remote,
+    not the the version in the local repository (if it exists).
 
     Note: either tag or branch must be supplied, but not both.
 
@@ -200,6 +225,8 @@ The root of the source tree will be referred to as `${SRC_ROOT}` below.
     externals description file pointed 'useful_library/sub-xternals.cfg',
     Then the main 'externals' field in the top level repo should point to
     'sub-externals.cfg'.
+
+  * Lines begining with '#' or ';' are comments and will be ignored.
 
 '''
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -71,7 +71,7 @@ test : utest stest
 #
 .PHONY : readme
 readme : $(CHECKOUT_EXE)
-	printf "%s\n" "-- AUTOMATICALLY GENERATED FILE. DO NOT EDIT --" > $(README)
+	printf "%s\n\n" "-- AUTOMATICALLY GENERATED FILE. DO NOT EDIT --" > $(README)
 	printf "%s" '[![Build Status](https://travis-ci.org/NCAR/manage_externals.svg?branch=master)](https://travis-ci.org/NCAR/manage_externals)' >> $(README)
 	printf "%s" '[![Coverage Status](https://coveralls.io/repos/github/NCAR/manage_externals/badge.svg?branch=master)](https://coveralls.io/github/NCAR/manage_externals?branch=master)' >> $(README)
 	printf "\n%s\n" '```' >> $(README)

--- a/test/test_unit_externals_description.py
+++ b/test/test_unit_externals_description.py
@@ -156,6 +156,14 @@ class TestModelDescritionConfigV1(unittest.TestCase):
         config.set(self._comp2_name, 'required', self._comp2_is_required)
         config.set(self._comp2_name, 'externals', self._comp2_externals)
 
+    @staticmethod
+    def _setup_externals_description(config):
+        """Add the required exernals description section
+        """
+
+        config.add_section(DESCRIPTION_SECTION)
+        config.set(DESCRIPTION_SECTION, VERSION_ITEM, '1.0.1')
+
     def _check_comp1(self, model):
         """Test that component one was constructed correctly.
         """
@@ -190,6 +198,7 @@ class TestModelDescritionConfigV1(unittest.TestCase):
         """
         config = config_parser()
         self._setup_comp1(config)
+        self._setup_externals_description(config)
         model = ExternalsDescriptionConfigV1(config)
         print(model)
         self._check_comp1(model)
@@ -199,6 +208,7 @@ class TestModelDescritionConfigV1(unittest.TestCase):
         """
         config = config_parser()
         self._setup_comp2(config)
+        self._setup_externals_description(config)
         model = ExternalsDescriptionConfigV1(config)
         print(model)
         self._check_comp2(model)
@@ -209,10 +219,41 @@ class TestModelDescritionConfigV1(unittest.TestCase):
         config = config_parser()
         self._setup_comp1(config)
         self._setup_comp2(config)
+        self._setup_externals_description(config)
         model = ExternalsDescriptionConfigV1(config)
         print(model)
         self._check_comp1(model)
         self._check_comp2(model)
+
+    def test_cfg_v1_reject_unknown_item(self):
+        """Test that a v1 description object will reject unknown items
+        """
+        config = config_parser()
+        self._setup_comp1(config)
+        self._setup_externals_description(config)
+        config.set(self._comp1_name, 'junk', 'foobar')
+        with self.assertRaises(RuntimeError):
+            ExternalsDescriptionConfigV1(config)
+
+    def test_cfg_v1_reject_v2(self):
+        """Test that a v1 description object won't try to parse a v2 file.
+        """
+        config = config_parser()
+        self._setup_comp1(config)
+        self._setup_externals_description(config)
+        config.set(DESCRIPTION_SECTION, VERSION_ITEM, '2.0.1')
+        with self.assertRaises(RuntimeError):
+            ExternalsDescriptionConfigV1(config)
+
+    def test_cfg_v1_reject_v1_too_new(self):
+        """Test that a v1 description object won't try to parse a v2 file.
+        """
+        config = config_parser()
+        self._setup_comp1(config)
+        self._setup_externals_description(config)
+        config.set(DESCRIPTION_SECTION, VERSION_ITEM, '1.100.0')
+        with self.assertRaises(RuntimeError):
+            ExternalsDescriptionConfigV1(config)
 
 
 class TestReadExternalsDescription(unittest.TestCase):
@@ -293,13 +334,22 @@ class TestCreateExternalsDescription(unittest.TestCase):
         self._config.add_section(DESCRIPTION_SECTION)
         self._config.set(DESCRIPTION_SECTION, VERSION_ITEM, '1.0.0')
 
-    def test_cfg_v1(self):
+    def test_cfg_v1_ok(self):
         """Test that a correct cfg v1 object is created by create_externals_description
 
         """
-        self._config.set(DESCRIPTION_SECTION, VERSION_ITEM, '1.2.3')
+        self._config.set(DESCRIPTION_SECTION, VERSION_ITEM, '1.0.3')
         ext = create_externals_description(self._config, model_format='cfg')
         self.assertIsInstance(ext, ExternalsDescriptionConfigV1)
+
+    def test_cfg_v1_unknown_version(self):
+        """Test that a config file with unknown schema version is rejected by
+        create_externals_description.
+
+        """
+        self._config.set(DESCRIPTION_SECTION, VERSION_ITEM, '100.0.3')
+        with self.assertRaises(RuntimeError):
+            create_externals_description(self._config, model_format='cfg')
 
     def test_dict(self):
         """Test that a correct cfg v1 object is created by create_externals_description


### PR DESCRIPTION
Update readme and help output

Update the readme and help output for checkout_externals to:

* clarify basic operation as explicit and data driver

* remove some cesm specific names in examples

* Document format externals description file and comments.
 
* Note that switching repositiory protocol is not supported. Must manually move
  the old repository.

* Document a work-around to avoid safety checks on modified files.

* Document that using the 'externals_only' protocol on the top level repository
  requires specifying the local_path as '.'

Testing:
    make test - python2 - all tests pass
