### PR TITLE
git: rework logic for determining in-sync and current ref name

### DIFF
--- a/manic/repository_git.py
+++ b/manic/repository_git.py
@@ -257,7 +257,6 @@ class GitRepository(Repository):
 
         # get the underlying hash of the expected ref
         _, expected_ref = self._git_revparse_commit(expected_ref)
-        # import pdb; pdb.set_trace()
         # compare the underlying hashes
         stat.sync_state = compare_refs(current_ref, expected_ref)
         if current_ref == EMPTY_STR:

--- a/manic/repository_git.py
+++ b/manic/repository_git.py
@@ -7,7 +7,6 @@ from __future__ import print_function
 
 import copy
 import os
-import re
 
 from .global_constants import EMPTY_STR, LOCAL_PATH_INDICATOR
 from .global_constants import VERBOSITY_VERBOSE

--- a/manic/repository_git.py
+++ b/manic/repository_git.py
@@ -197,7 +197,8 @@ class GitRepository(Repository):
             stat.sync_state = ExternalStatus.UNKNOWN
         else:
             # get the underlying hash of the expected ref
-            revparse_status, expected_ref_hash = self._git_revparse_commit(expected_ref)
+            revparse_status, expected_ref_hash = self._git_revparse_commit(
+                expected_ref)
             if revparse_status:
                 # We failed to get the hash associated with
                 # expected_ref. Maybe we should assign this to some special

--- a/manic/repository_git.py
+++ b/manic/repository_git.py
@@ -37,30 +37,6 @@ class GitRepository(Repository):
 
     """
 
-    # Note the distinction between "detached at" vs. "detached from": At
-    # least with recent versions of git, "detached at" means your HEAD
-    # is still at the same hash as the given reference; "detached from"
-    # means that your HEAD has moved past the hash corresponding to the
-    # given reference (branch or tag). (Ben Andre says that earlier
-    # versions of git, such as 1.8, did not distinguish between these
-    # situations, instead calling everything "detached from".)
-
-    # match XYZ of '* (HEAD detached at {XYZ}):
-    # e.g. * (HEAD detached at origin/feature-2)
-    RE_DETACHED_AT = re.compile(
-        r'\* \((?:[\w]+[\s]+)?detached at ([\w\-./]+)\)')
-
-    # match abc123 of '* (HEAD detached from XYZ) abc123':
-    # e.g. * (HEAD detached from origin/feature-2) abc123
-    # (where abc123 is the current hash)
-    RE_DETACHED_FROM = re.compile(
-        r'\* \((?:[\w]+[\s]+)?detached from [\w\-./]+\)[\s]+([\w]+)')
-
-
-    # match tracking reference info, return XYZ from [XYZ]
-    # e.g. [origin/master]
-    RE_TRACKING = re.compile(r'\[([\w\-./]+)(?::[\s]+[\w\s,]+)?\]')
-
     def __init__(self, component_name, repo):
         """
         Parse repo (a <repo> XML element).
@@ -109,110 +85,41 @@ class GitRepository(Repository):
         os.chdir(cwd)
 
     def _current_ref(self):
-        """Parse output of the 'git branch -vv' command to determine the *name* of current
-        branch, tag or hash. The line starting with '*' is the current branch. It
-        can be one of the following head states:
+        """Determine the *name* associated with HEAD.
 
-        1. On local branch
-
-              feature2 36418b4 [origin/feature2] Work on feature2
-            * feature3 36418b4 Work on feature2
-              master   9b75494 [origin/master] Initialize repository.
-
-        2. Detached at sha
-
-            * (HEAD detached at 36418b4) 36418b4 Work on feature2
-              feature2                   36418b4 [origin/feature2] Work on feature2
-              master                     9b75494 [origin/master] Initialize repository.
-
-        3. Detached at remote branch
-
-            * (HEAD detached at origin/feature2) 36418b4 Work on feature2
-              feature2                           36418b4 [origin/feature2] Work on feature2
-              feature3                           36418b4 Work on feature2
-              master                             9b75494 [origin/master] Initialize repository.
-
-        4. Detached at tag, still at exactly the tag
-
-            * (HEAD detached at clm4_5_18_r272) b837fc36 clm4_5_18_r272
-
-        5. Detached from a sha, development beyond the sha (not sure if
-           this will ever occur)
-
-            * (HEAD detached from 60b1cc1) 046eeac work on great new feature!
-              master                       9b75494 [origin/master] Initialize repository.
-
-        6. Detached from a branch, development beyond the branch
-
-            * (HEAD detached from origin/feature2) 1c455f6 work on great new feature!
-              master                               9b75494 [origin/master] Initialize repository.
-
-        7. Detached from a tag, development beyond the tag
-
-            * (HEAD detached from tag1) 3bcf79f work on great new feature!
-            master                    9b75494 [origin/master] Initialize repository.
-
-        8. On tracking branch. Note, may be may be ahead or behind remote.
-
-            * master 562bac9a [origin/master] more test junk
-
-            * master 408a8920 [origin/master: ahead 3] more junk
-
-            * master 408a8920 [origin/master: ahead 3, behind 2] more junk
-
-            * master 822d687d [origin/master: behind 3] more junk
-
-        NOTE: Parsing the output of the porcelain is probably not a
-        great idea, but there doesn't appear to be a single plumbing
-        command that will return the same info.
-
+        If we're on a branch, then returns the branch name; otherwise,
+        if we're on a tag, then returns the tag name; otherwise, returns
+        the current hash. Returns an empty string if no reference can be
+        determined (e.g., if we're not actually in a git repository).
         """
-        git_output = self._git_branch_vv()
-        lines = git_output.splitlines()
-        ref = ''
-        for line in lines:
-            if line.startswith('*'):
-                ref = line
-                break
-        current_ref = EMPTY_STR
-        if not ref:
-            # not a git repo? some other error? we return so the
-            # caller can handle.
-            pass
-        elif 'detached at' in ref:
-            match = self.RE_DETACHED_AT.search(ref)
-            try:
-                # In this case, match group 1 gives the reference we are
-                # detached at (e.g., the tag name)
-                current_ref = match.group(1)
-            except BaseException:
-                msg = 'DEV_ERROR: regex to detect "detached at" head state failed!'
-                msg += '\nref:\n{0}\ngit_output\n{1}\n'.format(ref, git_output)
-                fatal_error(msg)
-        elif 'detached from' in ref:
-            match = self.RE_DETACHED_FROM.search(ref)
-            try:
-                # In this case, match group 1 gives the current hash,
-                # because (at least with git v. 2) we are not actually
-                # at the given tag, but are beyond it
-                current_ref = match.group(1)
-            except BaseException:
-                msg = 'DEV_ERROR: regex to detect "detached from" head state failed!'
-                msg += '\nref:\n{0}\ngit_output\n{1}\n'.format(ref, git_output)
-                fatal_error(msg)
-        elif '[' in ref:
-            match = self.RE_TRACKING.search(ref)
-            try:
-                current_ref = match.group(1)
-            except BaseException:
-                msg = 'DEV_ERROR: regex to detect tracking branch failed.'
-                msg += '\nref:\n{0}\ngit_output\n{1}\n'.format(ref, git_output)
-                fatal_error(msg)
-        else:
-            # assumed local branch
-            current_ref = ref.split()[1]
+        ref_found = False
 
-        current_ref = current_ref.strip()
+        # If we're on a branch, then use that as the current ref
+        branch_found, branch_name = self._git_current_branch()
+        if branch_found:
+            current_ref = branch_name
+            ref_found = True
+
+        if not ref_found:
+            # Otherwise, if we're exactly at a tag, use that as the
+            # current ref
+            tag_found, tag_name = self._git_current_tag()
+            if tag_found:
+                current_ref = tag_name
+                ref_found = True
+
+        if not ref_found:
+            # Otherwise, use current hash as the current ref
+            hash_found, hash_name = self._git_current_hash()
+            if hash_found:
+                current_ref = hash_name
+                ref_found = True
+
+        if not ref_found:
+            # If we still can't find a ref, return empty string. This
+            # can happen if we're not actually in a git repo
+            current_ref = ''
+
         return current_ref
 
     def _check_sync(self, stat, repo_dir_path):
@@ -260,8 +167,7 @@ class GitRepository(Repository):
         os.chdir(repo_dir_path)
 
         # get the full hash of the current commit
-        current_ref = self._git_log_hash()
-        current_ref = current_ref.strip('"')
+        _, current_ref = self._git_current_hash()
 
         if self._branch:
             if self._url == LOCAL_PATH_INDICATOR:
@@ -650,24 +556,58 @@ class GitRepository(Repository):
     #
     # ----------------------------------------------------------------
     @staticmethod
-    def _git_log_hash():
-        """Run git log -1 --format='%H' to return the full hash of the
-        currently checkedout version.
+    def _git_current_hash():
+        """Return the full hash of the currently checked-out version.
 
+        Returns a tuple, (hash_found, hash), where hash_found is a
+        logical specifying whether a hash was found for HEAD (False
+        could mean we're not in a git repository at all). (If hash_found
+        is False, then hash is ''.)
         """
-        cmd = ['git', 'log', '-1', '--format="%H"']
-        git_output = execute_subprocess(cmd, output_to_caller=True)
-        return git_output.strip()
+        status, git_output = GitRepository._git_revparse_commit("HEAD")
+        hash_found = not status
+        if not hash_found:
+            git_output = ''
+        return hash_found, git_output
 
     @staticmethod
-    def _git_branch_vv():
-        """Run git branch -vv to obtain verbose branch information, including
-        upstream tracking and hash.
+    def _git_current_branch():
+        """Determines the name of the current branch.
 
+        Returns a tuple, (branch_found, branch_name), where branch_found
+        is a logical specifying whether a branch name was found for
+        HEAD. (If branch_found is False, then branch_name is ''.)
         """
-        cmd = ['git', 'branch', '--verbose', '--verbose']
-        git_output = execute_subprocess(cmd, output_to_caller=True)
-        return git_output
+        cmd = ['git', 'symbolic-ref', '--short', '-q', 'HEAD']
+        status, git_output = execute_subprocess(cmd,
+                                                output_to_caller=True,
+                                                status_to_caller=True)
+        branch_found = not status
+        if branch_found:
+            git_output = git_output.strip()
+        else:
+            git_output = ''
+        return branch_found, git_output
+
+    @staticmethod
+    def _git_current_tag():
+        """Determines the name tag corresponding to HEAD (if any).
+
+        Returns a tuple, (tag_found, tag_name), where tag_found is a
+        logical specifying whether we found a tag name corresponding to
+        HEAD. (If tag_found is False, then tag_name is ''.)
+        """
+        # git describe --exact-match --tags HEAD
+        cmd = ['git', 'describe', '--exact-match', '--tags', 'HEAD']
+        status, git_output = execute_subprocess(cmd,
+                                                output_to_caller=True,
+                                                status_to_caller=True)
+        tag_found = not status
+        if tag_found:
+            git_output = git_output.strip()
+        else:
+            git_output = ''
+        return tag_found, git_output
 
     @staticmethod
     def _git_showref_tag(ref):

--- a/test/test_sys_repository_git.py
+++ b/test/test_sys_repository_git.py
@@ -97,6 +97,10 @@ class TestGitRepositoryGitCommands(GitTestCase):
     # ========================================================================
 
     def setUp(self):
+        # directory we want to return to after the test system and
+        # checkout_externals are done cd'ing all over the place.
+        self._return_dir = os.getcwd()
+
         self._tmpdir = tempfile.mkdtemp()
         os.chdir(self._tmpdir)
 
@@ -121,6 +125,9 @@ class TestGitRepositoryGitCommands(GitTestCase):
         self._repo = GitRepository('test', repo)
 
     def tearDown(self):
+        # return to our common starting point
+        os.chdir(self._return_dir)
+
         shutil.rmtree(self._tmpdir, ignore_errors=True)
 
     @staticmethod

--- a/test/test_sys_repository_git.py
+++ b/test/test_sys_repository_git.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python
+
+"""Tests of some of the functionality in repository_git.py that actually
+interacts with git repositories.
+
+We're calling these "system" tests because we expect them to be a lot
+slower than most of the unit tests.
+
+"""
+
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from __future__ import print_function
+
+import os
+import shutil
+import tempfile
+import unittest
+
+from manic.repository_git import GitRepository
+from manic.externals_description import ExternalsDescription
+from manic.externals_description import ExternalsDescriptionDict
+from manic.utils import execute_subprocess
+
+class GitTestCase(unittest.TestCase):
+    """Adds some git-specific unit test functionality on top of TestCase"""
+
+    def assertIsHash(self, maybe_hash):
+        """Assert that the string given by maybe_hash really does look
+        like a git hash.
+        """
+
+        # Ensure it is non-empty
+        self.assertTrue(maybe_hash, msg="maybe_hash is empty")
+
+        # Ensure it has a single string
+        self.assertEqual(1, len(maybe_hash.split()),
+                         msg="maybe_hash has multiple strings: {}".format(maybe_hash))
+
+        # Ensure that the only characters in the string are ones allowed
+        # in hashes
+        allowed_chars_set = set('0123456789abcdef')
+        self.assertTrue(set(maybe_hash) <= allowed_chars_set,
+                        msg="maybe_hash has non-hash characters: {}".format(maybe_hash))
+
+class TestGitTestCase(GitTestCase):
+    """Tests GitTestCase"""
+
+    def test_assertIsHash_true(self):
+        self.assertIsHash('abc123')
+
+    def test_assertIsHash_empty(self):
+        with self.assertRaises(AssertionError):
+            self.assertIsHash('')
+
+    def test_assertIsHash_multipleStrings(self):
+        with self.assertRaises(AssertionError):
+            self.assertIsHash('abc123 def456')
+
+    def test_assertIsHash_badChar(self):
+        with self.assertRaises(AssertionError):
+            self.assertIsHash('abc123g')
+
+class TestGitRepositoryGitCommands(GitTestCase):
+
+    # ========================================================================
+    # Test helper functions
+    # ========================================================================
+
+    def setUp(self):
+        self._tmpdir = tempfile.mkdtemp()
+        os.chdir(self._tmpdir)
+
+        # It's silly that we need to create a repository in order to
+        # test these git commands. Much or all of the git functionality
+        # that is currently in repository_git.py should eventually be
+        # moved to a separate module that is solely responsible for
+        # wrapping git commands; that would allow us to test it
+        # independently of this repository class.
+        self._name = 'component'
+        rdata = {ExternalsDescription.PROTOCOL: 'git',
+                 ExternalsDescription.REPO_URL:
+                 '/path/to/local/repo',
+                 ExternalsDescription.TAG:
+                 'tag1',
+                 }
+
+        data = {self._name:
+                {
+                    ExternalsDescription.REQUIRED: False,
+                    ExternalsDescription.PATH: 'junk',
+                    ExternalsDescription.EXTERNALS: '',
+                    ExternalsDescription.REPO: rdata,
+                },
+                }
+        model = ExternalsDescriptionDict(data)
+        repo = model[self._name][ExternalsDescription.REPO]
+        self._repo = GitRepository('test', repo)
+
+
+    def tearDown(self):
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def make_git_repo(self):
+        """Turn the current directory into an empty git repository"""
+        execute_subprocess(['git', 'init'])
+
+    def add_git_commit(self):
+        """Add a git commit in the current directory"""
+        with open('README', 'a') as myfile:
+            myfile.write('more info')
+        execute_subprocess(['git', 'add', 'README'])
+        execute_subprocess(['git', 'commit', '-m', 'my commit message'])
+
+    def checkout_git_branch(self, branchname):
+        """Checkout a new branch in the current directory"""
+        execute_subprocess(['git', 'checkout', '-b', branchname])
+
+    def make_git_tag(self, tagname):
+        """Make a lightweight tag at the current commit"""
+        execute_subprocess(['git', 'tag', '-m', 'making a tag', tagname])
+
+    def checkout_ref(self, refname):
+        """Checkout the given refname in the current directory"""
+        execute_subprocess(['git', 'checkout', refname])
+
+    # ========================================================================
+    # Begin actual tests
+    # ========================================================================
+
+    def test_currentHash_returnsHash(self):
+        self.make_git_repo()
+        self.add_git_commit()
+        hash_found, myhash = self._repo._git_current_hash()
+        self.assertTrue(hash_found)
+        self.assertIsHash(myhash)
+
+    def test_currentHash_outsideGitRepo(self):
+        hash_found, myhash = self._repo._git_current_hash()
+        self.assertFalse(hash_found)
+        self.assertEqual('', myhash)
+
+    def test_currentBranch_onBranch(self):
+        self.make_git_repo()
+        self.add_git_commit()
+        self.checkout_git_branch('foo')
+        branch_found, mybranch = self._repo._git_current_branch()
+        self.assertTrue(branch_found)
+        self.assertEqual('foo', mybranch)
+
+    def test_currentBranch_notOnBranch(self):
+        self.make_git_repo()
+        self.add_git_commit()
+        self.make_git_tag('mytag')
+        self.checkout_ref('mytag')
+        branch_found, mybranch = self._repo._git_current_branch()
+        self.assertFalse(branch_found)
+        self.assertEqual('', mybranch)
+
+    def test_currentBranch_outsideGitRepo(self):
+        branch_found, mybranch = self._repo._git_current_branch()
+        self.assertFalse(branch_found)
+        self.assertEqual('', mybranch)
+
+    def test_currentTag_onTag(self):
+        self.make_git_repo()
+        self.add_git_commit()
+        self.make_git_tag('some_tag')
+        tag_found, mytag = self._repo._git_current_tag()
+        self.assertTrue(tag_found)
+        self.assertEqual('some_tag', mytag)
+
+    def test_currentTag_notOnTag(self):
+        self.make_git_repo()
+        self.add_git_commit()
+        self.make_git_tag('some_tag')
+        self.add_git_commit()
+        tag_found, mytag = self._repo._git_current_tag()
+        self.assertFalse(tag_found)
+        self.assertEqual('', mytag)
+
+    def test_currentTag_outsideGitRepo(self):
+        tag_found, mytag = self._repo._git_current_tag()
+        self.assertFalse(tag_found)
+        self.assertEqual('', mytag)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_sys_repository_git.py
+++ b/test/test_sys_repository_git.py
@@ -22,6 +22,7 @@ from manic.externals_description import ExternalsDescription
 from manic.externals_description import ExternalsDescriptionDict
 from manic.utils import execute_subprocess
 
+
 class GitTestCase(unittest.TestCase):
     """Adds some git-specific unit test functionality on top of TestCase"""
 
@@ -43,6 +44,7 @@ class GitTestCase(unittest.TestCase):
         self.assertTrue(set(maybe_hash) <= allowed_chars_set,
                         msg="maybe_hash has non-hash characters: {}".format(maybe_hash))
 
+
 class TestGitTestCase(GitTestCase):
     """Tests GitTestCase"""
 
@@ -60,6 +62,7 @@ class TestGitTestCase(GitTestCase):
     def test_assertIsHash_badChar(self):
         with self.assertRaises(AssertionError):
             self.assertIsHash('abc123g')
+
 
 class TestGitRepositoryGitCommands(GitTestCase):
 
@@ -96,7 +99,6 @@ class TestGitRepositoryGitCommands(GitTestCase):
         model = ExternalsDescriptionDict(data)
         repo = model[self._name][ExternalsDescription.REPO]
         self._repo = GitRepository('test', repo)
-
 
     def tearDown(self):
         shutil.rmtree(self._tmpdir, ignore_errors=True)
@@ -183,6 +185,7 @@ class TestGitRepositoryGitCommands(GitTestCase):
         tag_found, mytag = self._repo._git_current_tag()
         self.assertFalse(tag_found)
         self.assertEqual('', mytag)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_unit_repository_git.py
+++ b/test/test_unit_repository_git.py
@@ -95,7 +95,8 @@ class TestGitRepositoryCurrentRef(unittest.TestCase):
     def test_ref_branch(self):
         """Test that we correctly identify we are on a branch
         """
-        self._repo._git_current_branch = self._git_current_branch(True, 'feature3')
+        self._repo._git_current_branch = self._git_current_branch(
+            True, 'feature3')
         self._repo._git_current_tag = self._git_current_tag(True, 'foo_tag')
         self._repo._git_current_hash = self._git_current_hash(True, 'abc123')
         expected = 'feature3'
@@ -291,7 +292,8 @@ class TestGitRepositoryCheckSync(unittest.TestCase):
         self._repo._git_remote_verbose = self._git_remote_origin_upstream
         self._repo._tag = 'tag1'
         self._repo._git_current_hash = self._git_current_hash('')
-        self._repo._git_revparse_commit = self._git_revparse_commit('tag1', 1, '')
+        self._repo._git_revparse_commit = self._git_revparse_commit(
+            'tag1', 1, '')
         self._repo._check_sync(stat, self.TMP_FAKE_DIR)
         self.assertEqual(stat.sync_state, ExternalStatus.UNKNOWN)
         # check_sync should only modify the sync_state, not clean_state
@@ -310,7 +312,8 @@ class TestGitRepositoryCheckSync(unittest.TestCase):
         self._repo._git_remote_verbose = self._git_remote_origin_upstream
         self._repo._tag = 'tag1'
         self._repo._git_current_hash = self._git_current_hash('abc123')
-        self._repo._git_revparse_commit = self._git_revparse_commit('tag1', 1, '')
+        self._repo._git_revparse_commit = self._git_revparse_commit(
+            'tag1', 1, '')
         self._repo._check_sync_logic(stat, self.TMP_FAKE_DIR)
         self.assertEqual(stat.sync_state, ExternalStatus.MODEL_MODIFIED)
         # check_sync should only modify the sync_state, not clean_state
@@ -329,7 +332,8 @@ class TestGitRepositoryCheckSync(unittest.TestCase):
         self._repo._git_remote_verbose = self._git_remote_origin_upstream
         self._repo._tag = 'tag1'
         self._repo._git_current_hash = self._git_current_hash('abc123')
-        self._repo._git_revparse_commit = self._git_revparse_commit('tag1', 0, 'abc123')
+        self._repo._git_revparse_commit = self._git_revparse_commit(
+            'tag1', 0, 'abc123')
         self._repo._check_sync_logic(stat, self.TMP_FAKE_DIR)
         self.assertEqual(stat.sync_state, ExternalStatus.STATUS_OK)
         # check_sync should only modify the sync_state, not clean_state
@@ -343,7 +347,8 @@ class TestGitRepositoryCheckSync(unittest.TestCase):
         self._repo._git_remote_verbose = self._git_remote_origin_upstream
         self._repo._tag = 'tag1'
         self._repo._git_current_hash = self._git_current_hash('def456')
-        self._repo._git_revparse_commit = self._git_revparse_commit('tag1', 0, 'abc123')
+        self._repo._git_revparse_commit = self._git_revparse_commit(
+            'tag1', 0, 'abc123')
         self._repo._check_sync_logic(stat, self.TMP_FAKE_DIR)
         self.assertEqual(stat.sync_state, ExternalStatus.MODEL_MODIFIED)
         # check_sync should only modify the sync_state, not clean_state
@@ -363,7 +368,8 @@ class TestGitRepositoryCheckSync(unittest.TestCase):
         self._repo._tag = ''
         self._repo._hash = 'abc'
         self._repo._git_current_hash = self._git_current_hash('abc123')
-        self._repo._git_revparse_commit = self._git_revparse_commit('abc', 0, 'abc123')
+        self._repo._git_revparse_commit = self._git_revparse_commit(
+            'abc', 0, 'abc123')
         self._repo._check_sync_logic(stat, self.TMP_FAKE_DIR)
         self.assertEqual(stat.sync_state, ExternalStatus.STATUS_OK)
         # check_sync should only modify the sync_state, not clean_state
@@ -378,7 +384,8 @@ class TestGitRepositoryCheckSync(unittest.TestCase):
         self._repo._tag = ''
         self._repo._hash = 'abc'
         self._repo._git_current_hash = self._git_current_hash('def456')
-        self._repo._git_revparse_commit = self._git_revparse_commit('abc', 0, 'abc123')
+        self._repo._git_revparse_commit = self._git_revparse_commit(
+            'abc', 0, 'abc123')
         self._repo._check_sync_logic(stat, self.TMP_FAKE_DIR)
         self.assertEqual(stat.sync_state, ExternalStatus.MODEL_MODIFIED)
         # check_sync should only modify the sync_state, not clean_state

--- a/test/test_unit_repository_git.py
+++ b/test/test_unit_repository_git.py
@@ -14,7 +14,6 @@ from __future__ import print_function
 
 import os
 import shutil
-import string
 import unittest
 
 from manic.repository_git import GitRepository
@@ -69,6 +68,7 @@ class TestGitRepositoryCurrentRef(unittest.TestCase):
         """Return a function that takes the place of
         repo._git_current_branch, which returns the given output."""
         def my_git_current_branch():
+            """mock function that can take the place of repo._git_current_branch"""
             return branch_found, branch_name
         return my_git_current_branch
 
@@ -77,6 +77,7 @@ class TestGitRepositoryCurrentRef(unittest.TestCase):
         """Return a function that takes the place of
         repo._git_current_tag, which returns the given output."""
         def my_git_current_tag():
+            """mock function that can take the place of repo._git_current_tag"""
             return tag_found, tag_name
         return my_git_current_tag
 
@@ -85,6 +86,7 @@ class TestGitRepositoryCurrentRef(unittest.TestCase):
         """Return a function that takes the place of
         repo._git_current_hash, which returns the given output."""
         def my_git_current_hash():
+            """mock function that can take the place of repo._git_current_hash"""
             return hash_found, hash_name
         return my_git_current_hash
 
@@ -248,6 +250,7 @@ class TestGitRepositoryCheckSync(unittest.TestCase):
         which returns the given hash
         """
         def my_git_current_hash():
+            """mock function that can take the place of repo._git_current_hash"""
             return 0, myhash
         return my_git_current_hash
 
@@ -261,6 +264,7 @@ class TestGitRepositoryCheckSync(unittest.TestCase):
         status = 0 implies success, non-zero implies failure
         """
         def my_git_revparse_commit(ref):
+            """mock function that can take the place of repo._git_revparse_commit"""
             self.assertEqual(expected_ref, ref)
             return mystatus, myhash
         return my_git_revparse_commit


### PR DESCRIPTION
Rework two aspects of the logic for git repositories; both of these can
change behavior in some cases when printing status:

1. Determining whether the local checkout is in-sync with the expected
   reference from the configuration file: Now we always convert the
   expected reference to a hash and compare that with the
   currently-checked-out hash. Previously, we sometimes did the
   comparison using names, e.g., just ensuring that you're on the right
   branch.

2. Determining the current ref name (e.g., the branch or tag currently
   checked out). Now we use a number of plumbing commands rather than
   relying on regex parsing of 'git branch -vv'. The previous regex
   parsing was fragile and hard to maintain, and was the source of a
   number of bugs. In addition, differences between git v. 1 and git
   v. 2 meant that the result was incorrect in some cases -
   particularly, in the case where we have "detached from foo" (which is
   the text that always appeared for a detached head in v 1, but in v 2
   means we are no longer at foo).

I have also overhauled the unit tests covering this functionality. Many
tests were no longer needed with the new logic and so I have removed
them. I have added some other tests covering the new functionality.

User interface changes?: Yes
- Subtle changes to status output, as described above
- One particular change is: If we're on a tracking branch,
  `checkout_externals -S -v` will show the name of the local branch
  rather than the tracked branch. (This is more accurate, because we may
  not actually be at the head of the tracking branch.)

Fixes: #86 (Status incorrectly reports in-sync when you have made
commits in detached head state - fixed due to the change in (1)).

Testing:
  test removed: many no-longer-relevant unit tests
  unit tests: pass
  system tests: pass
  manual testing: basic manual testing of checking out and running
    status, in the context of cesm and ctsm
