### PR TITLE
Run a single coverage command rather than two separate commands

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -39,7 +39,7 @@ PYLINT_ARGS=-j 2 --rcfile=.pylint.rc
 
 # code coverage
 COVERAGE=coverage
-COVERAGE_ARGS=--rcfile=.coveragerc --append
+COVERAGE_ARGS=--rcfile=.coveragerc
 
 # source files
 SRC = \
@@ -92,10 +92,13 @@ lint : FORCE
 stylint : style lint
 
 .PHONY : coverage
+# Need to use a single coverage run with a single pattern rather than
+# using two separate commands with separate patterns for test_unit_*.py
+# and test_sys_*.py: The latter clobbers some results from the first
+# run, even if we use the --append flag to 'coverage run'.
 coverage : FORCE
 	$(PYPATH) $(COVERAGE) erase
-	$(PYPATH) $(COVERAGE) run $(COVERAGE_ARGS) $(TEST_ARGS) --pattern 'test_unit_*.py'
-	$(PYPATH) $(COVERAGE) run $(COVERAGE_ARGS) $(TEST_ARGS) --pattern 'test_sys_*.py'
+	$(PYPATH) $(COVERAGE) run $(COVERAGE_ARGS) $(TEST_ARGS) --pattern 'test_*.py'
 	$(PYPATH) $(COVERAGE) html
 
 #


### PR DESCRIPTION
I was finding that, even with the '--append' flag, some of the coverage
results were getting overwritten in the second run, resulting in a
too-low coverage report.

This turns out to have no effect on the reported coverage on master, but
it fixes the coverage report for #90: without this change, some lines
that are covered only by unit tests are listed as uncovered in the final
coverage report (at least, I think that's what was going on).

User interface changes?: No

Fixes: None

Testing:
  test removed: changed 'make coverage' operation
  unit tests:
  system tests:
  manual testing:
