### PR TITLE
Make more git and svn commands quiet

### DIFF
--- a/manic/checkout.py
+++ b/manic/checkout.py
@@ -320,12 +320,14 @@ def main(args):
 
     root_dir = os.path.abspath(os.getcwd())
     external_data = read_externals_description_file(root_dir, args.externals)
-    external = create_externals_description(external_data, components=args.components)
+    external = create_externals_description(
+        external_data, components=args.components)
 
     for comp in args.components:
         if comp not in external.keys():
-            fatal_error("No component {} found in {}".format(comp, args.externals))
-
+            fatal_error(
+                "No component {} found in {}".format(
+                    comp, args.externals))
 
     source_tree = SourceTree(root_dir, external)
     printlog('Checking status of externals: ', end='')

--- a/manic/externals_description.py
+++ b/manic/externals_description.py
@@ -91,16 +91,19 @@ def read_externals_description_file(root_dir, file_name):
     return externals_description
 
 
-def create_externals_description(model_data, model_format='cfg', components=None):
+def create_externals_description(
+        model_data, model_format='cfg', components=None):
     """Create the a externals description object from the provided data
     """
     externals_description = None
     if model_format == 'dict':
-        externals_description = ExternalsDescriptionDict(model_data, components=components)
+        externals_description = ExternalsDescriptionDict(
+            model_data, components=components)
     elif model_format == 'cfg':
         major, _, _ = get_cfg_schema_version(model_data)
         if major == 1:
-            externals_description = ExternalsDescriptionConfigV1(model_data, components=components)
+            externals_description = ExternalsDescriptionConfigV1(
+                model_data, components=components)
         else:
             msg = ('Externals description file has unsupported schema '
                    'version "{0}".'.format(major))

--- a/manic/repository_git.py
+++ b/manic/repository_git.py
@@ -694,7 +694,7 @@ class GitRepository(Repository):
     def _git_clone(url, repo_dir_name, verbosity):
         """Run git clone for the side effect of creating a repository.
         """
-        cmd = ['git', 'clone', url, repo_dir_name]
+        cmd = ['git', 'clone', '--quiet', url, repo_dir_name]
         if verbosity >= VERBOSITY_VERBOSE:
             printlog('    {0}'.format(' '.join(cmd)))
         execute_subprocess(cmd)
@@ -710,7 +710,7 @@ class GitRepository(Repository):
     def _git_fetch(remote_name):
         """Run the git fetch command to for the side effect of updating the repo
         """
-        cmd = ['git', 'fetch', '--tags', remote_name]
+        cmd = ['git', 'fetch', '--quiet', '--tags', remote_name]
         execute_subprocess(cmd)
 
     @staticmethod
@@ -721,7 +721,7 @@ class GitRepository(Repository):
         form 'origin/my_feature', or 'tag1'.
 
         """
-        cmd = ['git', 'checkout', ref]
+        cmd = ['git', 'checkout', '--quiet', ref]
         if verbosity >= VERBOSITY_VERBOSE:
             printlog('    {0}'.format(' '.join(cmd)))
         execute_subprocess(cmd)

--- a/manic/repository_svn.py
+++ b/manic/repository_svn.py
@@ -270,7 +270,7 @@ then rerun checkout_externals.
         """
         Switch branches for in an svn sandbox
         """
-        cmd = ['svn', 'switch', url]
+        cmd = ['svn', 'switch', '--quiet', url]
         if verbosity >= VERBOSITY_VERBOSE:
             printlog('    {0}'.format(' '.join(cmd)))
         execute_subprocess(cmd)


### PR DESCRIPTION
We've found that commands that do a lot of output can be slow when
called via python's subprocess. So make even more git and svn commands
quiet. These ones probably don't have a huge impact, but I can't see any
reason to keep them non-quiet.

Also run 'make style', which fixed some earlier commits.

User interface changes?: No

Fixes: none

Testing:
  test removed: none
  unit tests: pass
  system tests: pass
  manual testing: none

