### PR TITLE
catch errors from svn status --xml

### DIFF
--- a/manic/repository_svn.py
+++ b/manic/repository_svn.py
@@ -207,7 +207,7 @@ then rerun checkout_externals.
         is_dirty = False
         try:
             xml_status = ET.fromstring(svn_output)
-        except:
+        except BaseException:
             fatal_error("SVN returned invalid XML message {}".format(svn_output))
         xml_target = xml_status.find('./target')
         entries = xml_target.findall('./entry')

--- a/manic/repository_svn.py
+++ b/manic/repository_svn.py
@@ -205,7 +205,10 @@ then rerun checkout_externals.
         # pylint: enable=invalid-name
 
         is_dirty = False
-        xml_status = ET.fromstring(svn_output)
+        try:
+            xml_status = ET.fromstring(svn_output)
+        except:
+            fatal_error("SVN returned invalid XML message {}".format(svn_output))
         xml_target = xml_status.find('./target')
         entries = xml_target.findall('./entry')
         for entry in entries:


### PR DESCRIPTION
Capture errors returned from svn status --xml

The issue is that the svn command actually produces a malformed xml output in this case which manage_externals attempts to parse before printing the error.   This solution first attempts to parse the
xml returned from svn and bails and prints the raw output if it cannot.  The resulting output is a little ugly but readable.   

User interface changes?: No
[ If yes, describe what changed, and steps taken to ensure backward compatibilty ]

Fixes: #100 

Testing:
  test removed:
  unit tests: all pass
  system tests: 
  manual testing: Introduced a bad svn repo and tested 

