### PR TITLE
Make no-logging be the default

### DIFF
--- a/manic/checkout.py
+++ b/manic/checkout.py
@@ -279,8 +279,15 @@ The root of the source tree will be referred to as `${SRC_ROOT}` below.
                         help='DEVELOPER: output additional debugging '
                         'information to the screen and log file.')
 
-    parser.add_argument('--no-logging', action='store_true',
-                        help='DEVELOPER: disable logging.')
+    logging_group = parser.add_mutually_exclusive_group()
+
+    logging_group.add_argument('--logging', dest='do_logging',
+                               action='store_true',
+                               help='DEVELOPER: enable logging.')
+    logging_group.add_argument('--no-logging', dest='do_logging',
+                               action='store_false', default=False,
+                               help='DEVELOPER: disable logging '
+                               '(this is the default)')
 
     if args:
         options = parser.parse_args(args)
@@ -305,7 +312,7 @@ def main(args):
     *before* executing the checkout command - i.e., the status that it
     used to determine if it's safe to proceed with the checkout.
     """
-    if not args.no_logging:
+    if args.do_logging:
         logging.basicConfig(filename=LOG_FILE_NAME,
                             format='%(levelname)s : %(asctime)s : %(message)s',
                             datefmt='%Y-%m-%d %H:%M:%S',


### PR DESCRIPTION
@jedwards4b, @gold2718 and I all feel that no-logging should be the
default. This change is made here. I introduced a new --logging option
that can be used to turn on logging. I have maintained --no-logging as
an option for backwards compatibility - e.g., since cime calls
checkout_externals with '--no-logging' - but now --no-logging doesn't
actually do anything.

User interface changes?: Yes
`--no-logging` is now the default, new `--logging option` to turn on
logging.  I have kept `--no-logging` in place to ensure backwards
compatibility.

Fixes: #95 (Should not write to log file when running status command)
As noted in #97, @jedwards4b, @gold2718 and I felt that logging should
always be off by default.

Testing:
  test removed: none
  unit tests: pass
  system tests: pass
  manual testing: Ran with `--logging`, `--no-logging`, both and
    neither, with python2 and python3 (note that running with both
    generates an error message)
