### PR TITLE
if you encounter an empty directory clone into it

### DIFF
--- a/manic/repository_git.py
+++ b/manic/repository_git.py
@@ -55,7 +55,8 @@ class GitRepository(Repository):
         branch or tag.
         """
         repo_dir_path = os.path.join(base_dir_path, repo_dir_name)
-        if not os.path.exists(repo_dir_path):
+        repo_dir_exists = os.path.exists(repo_dir_path)
+        if (repo_dir_exists and not os.listdir(repo_dir_path)) or not repo_dir_exists:
             self._clone_repo(base_dir_path, repo_dir_name, verbosity)
         self._checkout_ref(repo_dir_path, verbosity)
 


### PR DESCRIPTION
If when cloning a git repository the root directory already exists but is empty go ahead and clone into it anyway.


User interface changes?: No

Fixes: #104 
Testing:
  test removed:
  unit tests: all pass
  system tests: all pass
  manual testing: mom6_interface

