### PR TITLE
Svn switch

### DIFF
--- a/manic/checkout.py
+++ b/manic/checkout.py
@@ -355,7 +355,7 @@ def main(args):
                 "No component {} found in {}".format(
                     comp, args.externals))
 
-    source_tree = SourceTree(root_dir, external, args.svn_ignore_ancestry)
+    source_tree = SourceTree(root_dir, external, svn_ignore_ancestry=args.svn_ignore_ancestry)
     printlog('Checking status of externals: ', end='')
     tree_status = source_tree.status()
     printlog('')

--- a/manic/checkout.py
+++ b/manic/checkout.py
@@ -280,6 +280,13 @@ of the externals description file or examine the output of
                         'used up to two times, increasing the '
                         'verbosity level each time.')
 
+    parser.add_argument('--svn-ignore-ancestry', action='store_true', default=False,
+                        help='By default, subversion will abort if a component is '
+                        'already checked out and there is no common ancestry with '
+                        'the new URL. This flag passes the "--ignore-ancestry" flag '
+                        'to the svn switch call. (This is not recommended unless '
+                        'you are sure about what you are doing.)')
+
     #
     # developer options
     #
@@ -348,7 +355,7 @@ def main(args):
                 "No component {} found in {}".format(
                     comp, args.externals))
 
-    source_tree = SourceTree(root_dir, external)
+    source_tree = SourceTree(root_dir, external, args.svn_ignore_ancestry)
     printlog('Checking status of externals: ', end='')
     tree_status = source_tree.status()
     printlog('')

--- a/manic/repository_factory.py
+++ b/manic/repository_factory.py
@@ -11,7 +11,7 @@ from .externals_description import ExternalsDescription
 from .utils import fatal_error
 
 
-def create_repository(component_name, repo_info):
+def create_repository(component_name, repo_info, svn_ignore_ancestry):
     """Determine what type of repository we have, i.e. git or svn, and
     create the appropriate object.
 
@@ -20,7 +20,7 @@ def create_repository(component_name, repo_info):
     if protocol == 'git':
         repo = GitRepository(component_name, repo_info)
     elif protocol == 'svn':
-        repo = SvnRepository(component_name, repo_info)
+        repo = SvnRepository(component_name, repo_info, svn_ignore_ancestry)
     elif protocol == 'externals_only':
         repo = None
     else:

--- a/manic/repository_factory.py
+++ b/manic/repository_factory.py
@@ -11,7 +11,7 @@ from .externals_description import ExternalsDescription
 from .utils import fatal_error
 
 
-def create_repository(component_name, repo_info, svn_ignore_ancestry):
+def create_repository(component_name, repo_info, svn_ignore_ancestry=False):
     """Determine what type of repository we have, i.e. git or svn, and
     create the appropriate object.
 
@@ -20,7 +20,7 @@ def create_repository(component_name, repo_info, svn_ignore_ancestry):
     if protocol == 'git':
         repo = GitRepository(component_name, repo_info)
     elif protocol == 'svn':
-        repo = SvnRepository(component_name, repo_info, svn_ignore_ancestry)
+        repo = SvnRepository(component_name, repo_info, ignore_ancestry=svn_ignore_ancestry)
     elif protocol == 'externals_only':
         repo = None
     else:

--- a/manic/repository_svn.py
+++ b/manic/repository_svn.py
@@ -37,11 +37,12 @@ class SvnRepository(Repository):
     """
     RE_URLLINE = re.compile(r'^URL:')
 
-    def __init__(self, component_name, repo):
+    def __init__(self, component_name, repo, ignore_ancestry):
         """
         Parse repo (a <repo> XML element).
         """
         Repository.__init__(self, component_name, repo)
+        self._ignore_ancestry = ignore_ancestry
         if self._branch:
             self._url = os.path.join(self._url, self._branch)
         elif self._tag:
@@ -69,7 +70,7 @@ class SvnRepository(Repository):
         if os.path.exists(repo_dir_path):
             cwd = os.getcwd()
             os.chdir(repo_dir_path)
-            self._svn_switch(self._url, verbosity)
+            self._svn_switch(self._url, self._ignore_ancestry, verbosity)
             # svn switch can lead to a conflict state, but it gives a
             # return code of 0. So now we need to make sure that we're
             # in a clean (non-conflict) state.
@@ -270,11 +271,14 @@ then rerun checkout_externals.
         execute_subprocess(cmd)
 
     @staticmethod
-    def _svn_switch(url, verbosity):
+    def _svn_switch(url, ignore_ancestry, verbosity):
         """
         Switch branches for in an svn sandbox
         """
-        cmd = ['svn', 'switch', '--quiet', url]
+        cmd = ['svn', 'switch', '--quiet']
+        if ignore_ancestry:
+          cmd.append('--ignore-ancestry')
+        cmd.append(url)
         if verbosity >= VERBOSITY_VERBOSE:
             printlog('    {0}'.format(' '.join(cmd)))
         execute_subprocess(cmd)

--- a/manic/repository_svn.py
+++ b/manic/repository_svn.py
@@ -37,7 +37,7 @@ class SvnRepository(Repository):
     """
     RE_URLLINE = re.compile(r'^URL:')
 
-    def __init__(self, component_name, repo, ignore_ancestry):
+    def __init__(self, component_name, repo, ignore_ancestry=False):
         """
         Parse repo (a <repo> XML element).
         """
@@ -277,7 +277,7 @@ then rerun checkout_externals.
         """
         cmd = ['svn', 'switch', '--quiet']
         if ignore_ancestry:
-          cmd.append('--ignore-ancestry')
+            cmd.append('--ignore-ancestry')
         cmd.append(url)
         if verbosity >= VERBOSITY_VERBOSE:
             printlog('    {0}'.format(' '.join(cmd)))

--- a/manic/sourcetree.py
+++ b/manic/sourcetree.py
@@ -24,7 +24,7 @@ class _External(object):
 
     # pylint: disable=R0902
 
-    def __init__(self, root_dir, name, ext_description):
+    def __init__(self, root_dir, name, ext_description, svn_ignore_ancestry):
         """Parse an external description file into a dictionary of externals.
 
         Input:
@@ -36,6 +36,8 @@ class _External(object):
             correspond to something in the path.
 
             ext_description : dict - source ExternalsDescription object
+
+            svn_ignore_ancestry : bool - use --ignore-externals with svn switch
 
         """
         self._name = name
@@ -62,7 +64,7 @@ class _External(object):
         if self._externals:
             self._create_externals_sourcetree()
         repo = create_repository(
-            name, ext_description[ExternalsDescription.REPO])
+            name, ext_description[ExternalsDescription.REPO], svn_ignore_ancestry)
         if repo:
             self._repo = repo
 
@@ -231,7 +233,7 @@ class SourceTree(object):
     SourceTree represents a group of managed externals
     """
 
-    def __init__(self, root_dir, model):
+    def __init__(self, root_dir, model, svn_ignore_ancestry=False):
         """
         Build a SourceTree object from a model description
         """
@@ -239,7 +241,7 @@ class SourceTree(object):
         self._all_components = {}
         self._required_compnames = []
         for comp in model:
-            src = _External(self._root_dir, comp, model[comp])
+            src = _External(self._root_dir, comp, model[comp], svn_ignore_ancestry)
             self._all_components[comp] = src
             if model[comp][ExternalsDescription.REQUIRED]:
                 self._required_compnames.append(comp)

--- a/manic/sourcetree.py
+++ b/manic/sourcetree.py
@@ -64,7 +64,8 @@ class _External(object):
         if self._externals:
             self._create_externals_sourcetree()
         repo = create_repository(
-            name, ext_description[ExternalsDescription.REPO], svn_ignore_ancestry)
+            name, ext_description[ExternalsDescription.REPO],
+            svn_ignore_ancestry=svn_ignore_ancestry)
         if repo:
             self._repo = repo
 


### PR DESCRIPTION
Add ability to pass --ignore-ancestry to svn switch

Add --svn-ignore-ancestry option to argparse, and then pass it
through many calls to SvnRepository constructor. If this variable
is True, run svn switch --ignore-ancestry.

User interface changes?: Yes - added optional --svn-ignore-ancestry command line argument
Note that omitting the option retains past behavior.

Fixes #105 -- provide way to suppress svn error when switching between release tags or from development to release

Testing:
  test removed: None
  unit tests: All Pass
  system tests: All Pass
  manual testing: Verified that adding --svn-ignore-ancestry suppresses previously-seen error

