### PR TITLE
New capability to use git submodule config to checkout externals

### DIFF
--- a/manic/externals_description.py
+++ b/manic/externals_description.py
@@ -64,8 +64,8 @@ VERSION_ITEM = 'schema_version'
 
 
 def read_externals_description_file(root_dir, file_name):
-    """Given a file name containing an externals description and
-    read it into it's internal representation.
+    """Read a file containing an externals description and
+    create its internal representation.
 
     """
     root_dir = os.path.abspath(root_dir)
@@ -139,10 +139,12 @@ class LstripReader(object):
         """Return the next line or raise StopIteration"""
         if self._index >= self._num_lines:
             raise StopIteration
-        else:
-            self._index = self._index + 1
-            return self._lines[self._index - 1]
 
+        self._index = self._index + 1
+        return self._lines[self._index - 1]
+
+    def __next__(self):
+        return self.next()
 
 def git_submodule_status(repo_dir):
     """Run the git submodule status command to obtain submodule hashes.

--- a/manic/externals_description.py
+++ b/manic/externals_description.py
@@ -22,14 +22,16 @@ import os
 import os.path
 import re
 
-# ConfigParser was renamed in python2 to configparser. In python2,
-# ConfigParser returns byte strings, str, instead of unicode. We need
-# unicode to be compatible with xml and json parser and python3.
+# ConfigParser in python2 was renamed to configparser in python3.
+# In python2, ConfigParser returns byte strings, str, instead of unicode.
+# We need unicode to be compatible with xml and json parser and python3.
 try:
     # python2
     from ConfigParser import SafeConfigParser as config_parser
     from ConfigParser import MissingSectionHeaderError
     from ConfigParser import NoSectionError, NoOptionError
+
+    USE_PYTHON2 = True
 
     def config_string_cleaner(text):
         """convert strings into unicode
@@ -41,6 +43,8 @@ except ImportError:
     from configparser import MissingSectionHeaderError
     from configparser import NoSectionError, NoOptionError
 
+    USE_PYTHON2 = False
+
     def config_string_cleaner(text):
         """Python3 already uses unicode strings, so just return the string
         without modification.
@@ -49,6 +53,7 @@ except ImportError:
         return text
 
 from .utils import printlog, fatal_error, str_to_bool, expand_local_url
+from .utils import execute_subprocess
 from .global_constants import EMPTY_STR, PPRINTER, VERSION_SEPERATOR
 
 #
@@ -59,8 +64,8 @@ VERSION_ITEM = 'schema_version'
 
 
 def read_externals_description_file(root_dir, file_name):
-    """Given a file name containing a externals description, determine the
-    format and read it into it's internal representation.
+    """Given a file name containing an externals description and
+    read it into it's internal representation.
 
     """
     root_dir = os.path.abspath(root_dir)
@@ -70,19 +75,27 @@ def read_externals_description_file(root_dir, file_name):
 
     file_path = os.path.join(root_dir, file_name)
     if not os.path.exists(file_name):
-        msg = ('ERROR: Model description file, "{0}", does not '
-               'exist at path:\n    {1}\nDid you run from the root of '
-               'the source tree?'.format(file_name, file_path))
+        if file_name.lower() == "none":
+            msg = ('INTERNAL ERROR: Attempt to read externals file '
+                   'from {0} when not configured'.format(file_path))
+        else:
+            msg = ('ERROR: Model description file, "{0}", does not '
+                   'exist at path:\n    {1}\nDid you run from the root of '
+                   'the source tree?'.format(file_name, file_path))
+
         fatal_error(msg)
 
     externals_description = None
-    try:
-        config = config_parser()
-        config.read(file_path)
-        externals_description = config
-    except MissingSectionHeaderError:
-        # not a cfg file
-        pass
+    if file_name == ExternalsDescription.GIT_SUBMODULES_FILENAME:
+        externals_description = read_gitmodules_file(root_dir, file_name)
+    else:
+        try:
+            config = config_parser()
+            config.read(file_path)
+            externals_description = config
+        except MissingSectionHeaderError:
+            # not a cfg file
+            pass
 
     if externals_description is None:
         msg = 'Unknown file format!'
@@ -90,9 +103,161 @@ def read_externals_description_file(root_dir, file_name):
 
     return externals_description
 
+class LstripReader(object):
+    "LstripReader formats .gitmodules files to be acceptable for configparser"
+    def __init__(self, filename):
+        with open(filename, 'r') as infile:
+            lines = infile.readlines()
+        self._lines = list()
+        self._num_lines = len(lines)
+        self._index = 0
+        for line in lines:
+            self._lines.append(line.lstrip())
+
+    def readlines(self):
+        """Return all the lines from this object's file"""
+        return self._lines
+
+    def readline(self, size=-1):
+        """Format and return the next line or raise StopIteration"""
+        try:
+            line = self.next()
+        except StopIteration:
+            line = ''
+
+        if (size > 0) and (len(line) < size):
+            return line[0:size]
+
+        return line
+
+    def __iter__(self):
+        """Begin an iteration"""
+        self._index = 0
+        return self
+
+    def next(self):
+        """Return the next line or raise StopIteration"""
+        if self._index >= self._num_lines:
+            raise StopIteration
+        else:
+            self._index = self._index + 1
+            return self._lines[self._index - 1]
+
+
+def git_submodule_status(repo_dir):
+    """Run the git submodule status command to obtain submodule hashes.
+        """
+    # This function is here instead of GitRepository to avoid a dependency loop
+    cwd = os.getcwd()
+    os.chdir(repo_dir)
+    cmd = ['git', 'submodule', 'status']
+    git_output = execute_subprocess(cmd, output_to_caller=True)
+    submodules = {}
+    submods = git_output.split('\n')
+    for submod in submods:
+        if submod:
+            status = submod[0]
+            items = submod[1:].split(' ')
+            if len(items) > 2:
+                tag = items[2]
+            else:
+                tag = None
+
+            submodules[items[1]] = {'hash':items[0], 'status':status, 'tag':tag}
+
+    os.chdir(cwd)
+    return submodules
+
+def parse_submodules_desc_section(section_items, file_path):
+    """Find the path and url for this submodule description"""
+    path = None
+    url = None
+    for item in section_items:
+        name = item[0].strip().lower()
+        if name == 'path':
+            path = item[1].strip()
+        elif name == 'url':
+            url = item[1].strip()
+        else:
+            msg = 'WARNING: Ignoring unknown {} property, in {}'
+            msg = msg.format(item[0], file_path) # fool pylint
+            logging.warning(msg)
+
+    return path, url
+
+def read_gitmodules_file(root_dir, file_name):
+    """Read a .gitmodules file and convert it to be compatible with an
+    externals description.
+    """
+    root_dir = os.path.abspath(root_dir)
+    msg = 'In directory : {0}'.format(root_dir)
+    logging.info(msg)
+    printlog('Processing submodules description file : {0}'.format(file_name))
+
+    file_path = os.path.join(root_dir, file_name)
+    if not os.path.exists(file_name):
+        msg = ('ERROR: submodules description file, "{0}", does not '
+               'exist at path:\n    {1}'.format(file_name, file_path))
+        fatal_error(msg)
+
+    submodules_description = None
+    externals_description = None
+    try:
+        config = config_parser()
+        if USE_PYTHON2:
+            config.readfp(LstripReader(file_path), filename=file_name)
+        else:
+            config.read_file(LstripReader(file_path), source=file_name)
+
+        submodules_description = config
+    except MissingSectionHeaderError:
+        # not a cfg file
+        pass
+
+    if submodules_description is None:
+        msg = 'Unknown file format!'
+        fatal_error(msg)
+    else:
+        # Convert the submodules description to an externals description
+        externals_description = config_parser()
+        # We need to grab all the commit hashes for this repo
+        submods = git_submodule_status(root_dir)
+        for section in submodules_description.sections():
+            if section[0:9] == 'submodule':
+                sec_name = section[9:].strip(' "')
+                externals_description.add_section(sec_name)
+                section_items = submodules_description.items(section)
+                path, url = parse_submodules_desc_section(section_items,
+                                                          file_path)
+
+                if path is None:
+                    msg = 'Submodule {} missing path'.format(sec_name)
+                    fatal_error(msg)
+
+                if url is None:
+                    msg = 'Submodule {} missing url'.format(sec_name)
+                    fatal_error(msg)
+
+                externals_description.set(sec_name,
+                                          ExternalsDescription.PATH, path)
+                externals_description.set(sec_name,
+                                          ExternalsDescription.PROTOCOL, 'git')
+                externals_description.set(sec_name,
+                                          ExternalsDescription.REPO_URL, url)
+                externals_description.set(sec_name,
+                                          ExternalsDescription.REQUIRED, 'True')
+                git_hash = submods[sec_name]['hash']
+                externals_description.set(sec_name,
+                                          ExternalsDescription.HASH, git_hash)
+
+        # Required items
+        externals_description.add_section(DESCRIPTION_SECTION)
+        externals_description.set(DESCRIPTION_SECTION, VERSION_ITEM, '1.0.0')
+
+    return externals_description
 
 def create_externals_description(
-        model_data, model_format='cfg', components=None):
+        model_data, model_format='cfg', components=None, parent_repo=None):
     """Create the a externals description object from the provided data
     """
     externals_description = None
@@ -103,7 +268,7 @@ def create_externals_description(
         major, _, _ = get_cfg_schema_version(model_data)
         if major == 1:
             externals_description = ExternalsDescriptionConfigV1(
-                model_data, components=components)
+                model_data, components=components, parent_repo=parent_repo)
         else:
             msg = ('Externals description file has unsupported schema '
                    'version "{0}".'.format(major))
@@ -173,18 +338,20 @@ class ExternalsDescription(dict):
     # keywords defining the interface into the externals description data
     EXTERNALS = 'externals'
     BRANCH = 'branch'
-    REPO = 'repo'
-    REQUIRED = 'required'
-    TAG = 'tag'
-    PATH = 'local_path'
-    PROTOCOL = 'protocol'
-    REPO_URL = 'repo_url'
+    SUBMODULE = 'from_submodule'
     HASH = 'hash'
     NAME = 'name'
+    PATH = 'local_path'
+    PROTOCOL = 'protocol'
+    REPO = 'repo'
+    REPO_URL = 'repo_url'
+    REQUIRED = 'required'
+    TAG = 'tag'
 
     PROTOCOL_EXTERNALS_ONLY = 'externals_only'
     PROTOCOL_GIT = 'git'
     PROTOCOL_SVN = 'svn'
+    GIT_SUBMODULES_FILENAME = '.gitmodules'
     KNOWN_PRROTOCOLS = [PROTOCOL_GIT, PROTOCOL_SVN, PROTOCOL_EXTERNALS_ONLY]
 
     # v1 xml keywords
@@ -197,15 +364,16 @@ class ExternalsDescription(dict):
     _source_schema = {REQUIRED: True,
                       PATH: 'string',
                       EXTERNALS: 'string',
+                      SUBMODULE : True,
                       REPO: {PROTOCOL: 'string',
                              REPO_URL: 'string',
                              TAG: 'string',
                              BRANCH: 'string',
                              HASH: 'string',
-                             }
-                      }
+                            }
+                     }
 
-    def __init__(self):
+    def __init__(self, parent_repo=None):
         """Convert the xml into a standardized dict that can be used to
         construct the source objects
 
@@ -218,6 +386,7 @@ class ExternalsDescription(dict):
         self._input_major = None
         self._input_minor = None
         self._input_patch = None
+        self._parent_repo = parent_repo
 
     def _verify_schema_version(self):
         """Use semantic versioning rules to verify we can process this schema.
@@ -265,6 +434,7 @@ class ExternalsDescription(dict):
         self._validate()
 
     def _check_data(self):
+        # pylint: disable=too-many-branches,too-many-statements
         """Check user supplied data is valid where possible.
         """
         for ext_name in self.keys():
@@ -281,6 +451,13 @@ class ExternalsDescription(dict):
                            'may not include the "hash" keyword.'.format(
                                ext_name))
                     fatal_error(msg)
+
+            if ((self[ext_name][self.REPO][self.PROTOCOL] != self.PROTOCOL_GIT)
+                    and (self.SUBMODULE in self[ext_name])):
+                msg = ('self.SUBMODULE is only supported with {0} protocol, '
+                       '"{1}" is defined as an {2} repository')
+                fatal_error(msg.format(self.PROTOCOL_GIT, ext_name,
+                                       self[ext_name][self.REPO][self.PROTOCOL]))
 
             if (self[ext_name][self.REPO][self.PROTOCOL] !=
                     self.PROTOCOL_EXTERNALS_ONLY):
@@ -301,11 +478,23 @@ class ExternalsDescription(dict):
                     found_refs = '"{0} = {1}", {2}'.format(
                         self.HASH, self[ext_name][self.REPO][self.HASH],
                         found_refs)
+                if (self.SUBMODULE in self[ext_name] and
+                        self[ext_name][self.SUBMODULE]):
+                    ref_count += 1
+                    found_refs = '"{0} = {1}", {2}'.format(
+                        self.SUBMODULE,
+                        self[ext_name][self.SUBMODULE], found_refs)
 
                 if ref_count > 1:
-                    msg = ('Model description is over specified! Only one of '
-                           '"tag", "branch", or "hash" may be specified for '
-                           'repo description of "{0}".'.format(ext_name))
+                    msg = 'Model description is over specified! '
+                    if self.SUBMODULE in self[ext_name]:
+                        msg += ('from_submodule is not compatible with '
+                                '"tag", "branch", or "hash" ')
+                    else:
+                        msg += (' Only one of "tag", "branch", or "hash" '
+                                'may be specified ')
+
+                    msg += 'for repo description of "{0}".'.format(ext_name)
                     msg = '{0}\nFound: {1}'.format(msg, found_refs)
                     fatal_error(msg)
                 elif ref_count < 1:
@@ -314,17 +503,39 @@ class ExternalsDescription(dict):
                            'repo description of "{0}"'.format(ext_name))
                     fatal_error(msg)
 
-                if self.REPO_URL not in self[ext_name][self.REPO]:
+                if (self.REPO_URL not in self[ext_name][self.REPO] and
+                        (self.SUBMODULE not in self[ext_name] or
+                         not self[ext_name][self.SUBMODULE])):
                     msg = ('Model description is under specified! Must have '
                            '"repo_url" in repo '
                            'description for "{0}"'.format(ext_name))
                     fatal_error(msg)
 
-                url = expand_local_url(
-                    self[ext_name][self.REPO][self.REPO_URL], ext_name)
-                self[ext_name][self.REPO][self.REPO_URL] = url
+                if (self.SUBMODULE in self[ext_name] and
+                        self[ext_name][self.SUBMODULE]):
+                    if self.REPO_URL in self[ext_name][self.REPO]:
+                        msg = ('Model description is over specified! '
+                               'from_submodule keyword is not compatible '
+                               'with {0} keyword for'.format(self.REPO_URL))
+                        msg = '{0} repo description of "{1}"'.format(msg,
+                                                                     ext_name)
+                        fatal_error(msg)
+
+                    if self.PATH in self[ext_name]:
+                        msg = ('Model description is over specified! '
+                               'from_submodule keyword is not compatible with '
+                               '{0} keyword for'.format(self.PATH))
+                        msg = '{0} repo description of "{1}"'.format(msg,
+                                                                     ext_name)
+                        fatal_error(msg)
+
+                if self.REPO_URL in self[ext_name][self.REPO]:
+                    url = expand_local_url(
+                        self[ext_name][self.REPO][self.REPO_URL], ext_name)
+                    self[ext_name][self.REPO][self.REPO_URL] = url
 
     def _check_optional(self):
+        # pylint: disable=too-many-branches
         """Some fields like externals, repo:tag repo:branch are
         (conditionally) optional. We don't want the user to be
         required to enter them in every externals description file, but
@@ -332,6 +543,7 @@ class ExternalsDescription(dict):
         default values if appropriate.
 
         """
+        submod_desc = None      # Only load submodules info once
         for field in self:
             # truely optional
             if self.EXTERNALS not in self[field]:
@@ -346,6 +558,70 @@ class ExternalsDescription(dict):
                 self[field][self.REPO][self.HASH] = EMPTY_STR
             if self.REPO_URL not in self[field][self.REPO]:
                 self[field][self.REPO][self.REPO_URL] = EMPTY_STR
+
+            # from_submodule has a complex relationship with other fields
+            if self.SUBMODULE in self[field]:
+                # User wants to use submodule information, is it available?
+                if self._parent_repo is None:
+                    # No parent == no submodule information
+                    PPRINTER.pprint(self[field])
+                    msg = 'No parent submodule for "{0}"'.format(field)
+                    fatal_error(msg)
+                elif self._parent_repo.protocol() != self.PROTOCOL_GIT:
+                    PPRINTER.pprint(self[field])
+                    msg = 'Parent protocol, "{0}", does not support submodules'
+                    fatal_error(msg.format(self._parent_repo.protocol()))
+                else:
+                    args = self._repo_config_from_submodule(field, submod_desc)
+                    repo_url, repo_path, ref_hash, submod_desc = args
+
+                    if repo_url is None:
+                        msg = ('Cannot checkout "{0}" as a submodule, '
+                               'repo not found in {1} file')
+                        fatal_error(msg.format(field,
+                                               self.GIT_SUBMODULES_FILENAME))
+                    # Fill in submodule fields
+                    self[field][self.REPO][self.REPO_URL] = repo_url
+                    self[field][self.REPO][self.HASH] = ref_hash
+                    self[field][self.PATH] = repo_path
+
+                if self[field][self.SUBMODULE]:
+                    # We should get everything from the parent submodule
+                    # configuration.
+                    pass
+                # No else (from _submodule = False is the default)
+            else:
+                # Add the default value (not using submodule information)
+                self[field][self.SUBMODULE] = False
+
+    def _repo_config_from_submodule(self, field, submod_desc):
+        """Find the external config information for a repository from
+        its submodule configuration information.
+        """
+        if submod_desc is None:
+            repo_path = os.getcwd() # Is this always correct?
+            submod_file = self._parent_repo.submodules_file(repo_path=repo_path)
+            if submod_file is None:
+                msg = ('Cannot checkout "{0}" from submodule information\n'
+                       '       Parent repo, "{1}" does not have submodules')
+                fatal_error(msg.format(field, self._parent_repo.name()))
+
+            submod_file = read_gitmodules_file(repo_path, submod_file)
+            submod_desc = create_externals_description(submod_file)
+
+        # Can we find our external?
+        repo_url = None
+        repo_path = None
+        ref_hash = None
+        for ext_field in submod_desc:
+            if field == ext_field:
+                ext = submod_desc[ext_field]
+                repo_url = ext[self.REPO][self.REPO_URL]
+                repo_path = ext[self.PATH]
+                ref_hash = ext[self.REPO][self.HASH]
+                break
+
+        return repo_url, repo_path, ref_hash, submod_desc
 
     def _validate(self):
         """Validate that the parsed externals description contains all necessary
@@ -383,11 +659,12 @@ class ExternalsDescription(dict):
             if isinstance(schema, dict) and isinstance(data, dict):
                 # Both are dicts, recursively verify that all fields
                 # in schema are present in the data.
-                for k in schema:
-                    in_ref = in_ref and (k in data)
+                for key in schema:
+                    in_ref = in_ref and (key in data)
                     if in_ref:
                         valid = valid and (
-                            validate_data_struct(schema[k], data[k]))
+                            validate_data_struct(schema[key], data[key]))
+
                 is_valid = in_ref and valid
             else:
                 # non-recursive structure. verify data and schema have
@@ -434,9 +711,9 @@ class ExternalsDescriptionDict(ExternalsDescription):
         self._input_patch = 0
         self._verify_schema_version()
         if components:
-            for k in model_data.items():
-                if k not in components:
-                    del model_data[k]
+            for key in model_data.items():
+                if key not in components:
+                    del model_data[key]
 
         self.update(model_data)
         self._check_user_input()
@@ -448,12 +725,12 @@ class ExternalsDescriptionConfigV1(ExternalsDescription):
 
     """
 
-    def __init__(self, model_data, components=None):
+    def __init__(self, model_data, components=None, parent_repo=None):
         """Convert the config data into a standardized dict that can be used to
         construct the source objects
 
         """
-        ExternalsDescription.__init__(self)
+        ExternalsDescription.__init__(self, parent_repo=parent_repo)
         self._schema_major = 1
         self._schema_minor = 1
         self._schema_patch = 0

--- a/manic/externals_description.py
+++ b/manic/externals_description.py
@@ -188,6 +188,8 @@ def parse_submodules_desc_section(section_items, file_path):
     return path, url
 
 def read_gitmodules_file(root_dir, file_name):
+    # pylint: disable=deprecated-method
+    # Disabling this check because the method is only used for python2
     """Read a .gitmodules file and convert it to be compatible with an
     externals description.
     """

--- a/manic/repository.py
+++ b/manic/repository.py
@@ -46,6 +46,8 @@ class Repository(object):
         correct URL, correct branch or tag), and possibly update the source.
         If the repo destination directory does not exist, checkout the correce
         branch or tag.
+        NB: <recursive> is include as an argument for compatibility with
+            git functionality (repository_git.py)
         """
         msg = ('DEV_ERROR: checkout method must be implemented in all '
                'repository classes! {0}'.format(self.__class__.__name__))
@@ -59,7 +61,8 @@ class Repository(object):
                'repository classes! {0}'.format(self.__class__.__name__))
         fatal_error(msg)
 
-    def submodules_file(self): # pylint: disable=no-self-use
+    def submodules_file(self, repo_path=None):
+        # pylint: disable=no-self-use,unused-argument
         """Stub for use by non-git VC systems"""
         return None
 

--- a/manic/repository.py
+++ b/manic/repository.py
@@ -40,7 +40,7 @@ class Repository(object):
             fatal_error('repo {0} must have exactly one of '
                         'tag, branch or hash.'.format(self._name))
 
-    def checkout(self, base_dir_path, repo_dir_name, verbosity):  # pylint: disable=unused-argument
+    def checkout(self, base_dir_path, repo_dir_name, verbosity, recursive):  # pylint: disable=unused-argument
         """
         If the repo destination directory exists, ensure it is correct (from
         correct URL, correct branch or tag), and possibly update the source.
@@ -58,6 +58,10 @@ class Repository(object):
         msg = ('DEV_ERROR: status method must be implemented in all '
                'repository classes! {0}'.format(self.__class__.__name__))
         fatal_error(msg)
+
+    def submodules_file(self): # pylint: disable=no-self-use
+        """Stub for use by non-git VC systems"""
+        return None
 
     def url(self):
         """Public access of repo url.
@@ -78,3 +82,13 @@ class Repository(object):
         """Public access of repo hash.
         """
         return self._hash
+
+    def name(self):
+        """Public access of repo name.
+        """
+        return self._name
+
+    def protocol(self):
+        """Public access of repo protocol.
+        """
+        return self._protocol

--- a/manic/repository_git.py
+++ b/manic/repository_git.py
@@ -781,7 +781,10 @@ class GitRepository(Repository):
         """Run git submodule update for the side effect of updating this
         repo's submodules.
         """
-        cmd = ['git', 'submodule', 'update', '--init', '--recursive']
-        if verbosity >= VERBOSITY_VERBOSE:
-            printlog('    {0}'.format(' '.join(cmd)))
-        execute_subprocess(cmd)
+        # First, verify that we have a .gitmodules file
+        if os.path.exists(ExternalsDescription.GIT_SUBMODULES_FILENAME):
+            cmd = ['git', 'submodule', 'update', '--init', '--recursive']
+            if verbosity >= VERBOSITY_VERBOSE:
+                printlog('    {0}'.format(' '.join(cmd)))
+
+            execute_subprocess(cmd)

--- a/manic/repository_svn.py
+++ b/manic/repository_svn.py
@@ -64,6 +64,8 @@ class SvnRepository(Repository):
 
         If the repo destination directory does not exist, checkout the
         correct branch or tag.
+        NB: <recursive> is include as an argument for compatibility with
+            git functionality (repository_git.py)
 
         """
         repo_dir_path = os.path.join(base_dir_path, repo_dir_name)

--- a/manic/repository_svn.py
+++ b/manic/repository_svn.py
@@ -56,7 +56,7 @@ class SvnRepository(Repository):
     # Public API, defined by Repository
     #
     # ----------------------------------------------------------------
-    def checkout(self, base_dir_path, repo_dir_name, verbosity):
+    def checkout(self, base_dir_path, repo_dir_name, verbosity, recursive):  # pylint: disable=unused-argument
         """Checkout or update the working copy
 
         If the repo destination directory exists, switch the sandbox to
@@ -138,9 +138,7 @@ in the new revision.
 
 To recover: Clean up the above directory (resolving conflicts, etc.),
 then rerun checkout_externals.
-""".format(cwd=repo_dir_path,
-                message=message,
-                status=status)
+""".format(cwd=repo_dir_path, message=message, status=status)
 
             fatal_error(errmsg)
 

--- a/manic/sourcetree.py
+++ b/manic/sourcetree.py
@@ -11,11 +11,11 @@ from .externals_description import ExternalsDescription
 from .externals_description import read_externals_description_file
 from .externals_description import create_externals_description
 from .repository_factory import create_repository
+from .repository_git import GitRepository
 from .externals_status import ExternalStatus
 from .utils import fatal_error, printlog
 from .global_constants import EMPTY_STR, LOCAL_PATH_INDICATOR
 from .global_constants import VERBOSITY_VERBOSE
-
 
 class _External(object):
     """
@@ -61,13 +61,19 @@ class _External(object):
 
         self._required = ext_description[ExternalsDescription.REQUIRED]
         self._externals = ext_description[ExternalsDescription.EXTERNALS]
-        if self._externals:
-            self._create_externals_sourcetree()
+        # Treat a .gitmodules file as a backup externals config
+        if not self._externals:
+            if GitRepository.has_submodules(self._repo_dir_path):
+                self._externals = ExternalsDescription.GIT_SUBMODULES_FILENAME
+
         repo = create_repository(
             name, ext_description[ExternalsDescription.REPO],
             svn_ignore_ancestry=svn_ignore_ancestry)
         if repo:
             self._repo = repo
+
+        if self._externals and (self._externals.lower() != 'none'):
+            self._create_externals_sourcetree()
 
     def get_name(self):
         """
@@ -125,7 +131,7 @@ class _External(object):
             if self._externals and self._externals_sourcetree:
                 # we expect externals and they exist
                 cwd = os.getcwd()
-                # SourceTree expecteds to be called from the correct
+                # SourceTree expects to be called from the correct
                 # root directory.
                 os.chdir(self._repo_dir_path)
                 ext_stats = self._externals_sourcetree.status(self._local_path)
@@ -148,7 +154,7 @@ class _External(object):
         """
         If the repo destination directory exists, ensure it is correct (from
         correct URL, correct branch or tag), and possibly update the external.
-        If the repo destination directory does not exist, checkout the correce
+        If the repo destination directory does not exist, checkout the correct
         branch or tag.
         If load_all is True, also load all of the the externals sub-externals.
         """
@@ -183,13 +189,14 @@ class _External(object):
                 checkout_verbosity = verbosity - 1
             else:
                 checkout_verbosity = verbosity
-            self._repo.checkout(self._base_dir_path,
-                                self._repo_dir_name, checkout_verbosity)
+
+            self._repo.checkout(self._base_dir_path, self._repo_dir_name,
+                                checkout_verbosity, self.clone_recursive())
 
     def checkout_externals(self, verbosity, load_all):
         """Checkout the sub-externals for this object
         """
-        if self._externals:
+        if self.load_externals():
             if self._externals_sourcetree:
                 # NOTE(bja, 2018-02): the subtree externals objects
                 # were created during initial status check. Updating
@@ -200,6 +207,24 @@ class _External(object):
                 self._externals_sourcetree = None
             self._create_externals_sourcetree()
             self._externals_sourcetree.checkout(verbosity, load_all)
+
+    def load_externals(self):
+        'Return True iff an externals file should be loaded'
+        load_ex = False
+        if os.path.exists(self._repo_dir_path):
+            if self._externals:
+                if self._externals.lower() != 'none':
+                    load_ex = os.path.exists(os.path.join(self._repo_dir_path,
+                                                          self._externals))
+
+        return load_ex
+
+    def clone_recursive(self):
+        'Return True iff any .gitmodules files should be processed'
+        # Try recursive unless there is an externals entry
+        recursive = not self._externals
+
+        return recursive
 
     def _create_externals_sourcetree(self):
         """
@@ -213,6 +238,15 @@ class _External(object):
 
         cwd = os.getcwd()
         os.chdir(self._repo_dir_path)
+        if self._externals.lower() == 'none':
+            msg = ('Internal: Attempt to create source tree for '
+                   'externals = none in {}'.format(self._repo_dir_path))
+            fatal_error(msg)
+
+        if not os.path.exists(self._externals):
+            if GitRepository.has_submodules():
+                self._externals = ExternalsDescription.GIT_SUBMODULES_FILENAME
+
         if not os.path.exists(self._externals):
             # NOTE(bja, 2017-10) this check is redundent with the one
             # in read_externals_description_file!
@@ -224,10 +258,10 @@ class _External(object):
         externals_root = self._repo_dir_path
         model_data = read_externals_description_file(externals_root,
                                                      self._externals)
-        externals = create_externals_description(model_data)
+        externals = create_externals_description(model_data,
+                                                 parent_repo=self._repo)
         self._externals_sourcetree = SourceTree(externals_root, externals)
         os.chdir(cwd)
-
 
 class SourceTree(object):
     """

--- a/test/test_sys_checkout.py
+++ b/test/test_sys_checkout.py
@@ -551,7 +551,7 @@ class BaseTestSysCheckout(unittest.TestCase):
             dest_dir = dest_dir_in
 
         # pylint: disable=W0212
-        GitRepository._git_clone(parent_repo_dir, dest_dir, VERBOSITY_DEFAULT, False)
+        GitRepository._git_clone(parent_repo_dir, dest_dir, VERBOSITY_DEFAULT)
         return dest_dir
 
     @staticmethod

--- a/test/test_sys_checkout.py
+++ b/test/test_sys_checkout.py
@@ -42,6 +42,7 @@ import unittest
 
 from manic.externals_description import ExternalsDescription
 from manic.externals_description import DESCRIPTION_SECTION, VERSION_ITEM
+from manic.externals_description import git_submodule_status
 from manic.externals_status import ExternalStatus
 from manic.repository_git import GitRepository
 from manic.utils import printlog, execute_subprocess
@@ -139,7 +140,7 @@ class GenerateExternalsDescriptionCfgV1(object):
         self.create_section(MIXED_REPO_NAME, 'mixed_req',
                             branch='master', externals=CFG_SUB_NAME)
 
-        self._write_config(dest_dir)
+        self.write_config(dest_dir)
 
     def container_simple_required(self, dest_dir):
         """Create a container externals file with only simple externals.
@@ -155,7 +156,7 @@ class GenerateExternalsDescriptionCfgV1(object):
         self.create_section(SIMPLE_REPO_NAME, 'simp_hash',
                             ref_hash='60b1cc1a38d63')
 
-        self._write_config(dest_dir)
+        self.write_config(dest_dir)
 
     def container_simple_optional(self, dest_dir):
         """Create a container externals file with optional simple externals
@@ -168,7 +169,7 @@ class GenerateExternalsDescriptionCfgV1(object):
         self.create_section(SIMPLE_REPO_NAME, 'simp_opt',
                             tag='tag1', required=False)
 
-        self._write_config(dest_dir)
+        self.write_config(dest_dir)
 
     def container_simple_svn(self, dest_dir):
         """Create a container externals file with only simple externals.
@@ -180,7 +181,7 @@ class GenerateExternalsDescriptionCfgV1(object):
         self.create_svn_external('svn_branch', branch='trunk')
         self.create_svn_external('svn_tag', tag='tags/cesm2.0.beta07')
 
-        self._write_config(dest_dir)
+        self.write_config(dest_dir)
 
     def mixed_simple_base(self, dest_dir):
         """Create a mixed-use base externals file with only simple externals.
@@ -197,7 +198,7 @@ class GenerateExternalsDescriptionCfgV1(object):
         self.create_section(SIMPLE_REPO_NAME, 'simp_hash',
                             ref_hash='60b1cc1a38d63')
 
-        self._write_config(dest_dir)
+        self.write_config(dest_dir)
 
     def mixed_simple_sub(self, dest_dir):
         """Create a mixed-use sub externals file with only simple externals.
@@ -211,9 +212,9 @@ class GenerateExternalsDescriptionCfgV1(object):
                             branch=REMOTE_BRANCH_FEATURE2,
                             path=SUB_EXTERNALS_PATH)
 
-        self._write_config(dest_dir, filename=CFG_SUB_NAME)
+        self.write_config(dest_dir, filename=CFG_SUB_NAME)
 
-    def _write_config(self, dest_dir, filename=CFG_NAME):
+    def write_config(self, dest_dir, filename=CFG_NAME):
         """Write the configuration file to disk
 
         """
@@ -237,22 +238,40 @@ class GenerateExternalsDescriptionCfgV1(object):
                          self._schema_version)
 
     def create_section(self, repo_type, name, tag='', branch='',
-                       ref_hash='',
-                       required=True, path=EXTERNALS_NAME, externals=''):
+                       ref_hash='', required=True, path=EXTERNALS_NAME,
+                       externals='', repo_path=None, from_submodule=False):
+        # pylint: disable=too-many-branches
         """Create a config section with autofilling some items and handling
         optional items.
 
         """
         # pylint: disable=R0913
         self._config.add_section(name)
-        self._config.set(name, ExternalsDescription.PATH,
-                         os.path.join(path, name))
+        if not from_submodule:
+            self._config.set(name, ExternalsDescription.PATH,
+                             os.path.join(path, name))
 
         self._config.set(name, ExternalsDescription.PROTOCOL,
                          ExternalsDescription.PROTOCOL_GIT)
 
-        repo_url = os.path.join('${MANIC_TEST_BARE_REPO_ROOT}', repo_type)
-        self._config.set(name, ExternalsDescription.REPO_URL, repo_url)
+        # from_submodules is incompatible with some other options, turn them off
+        if (from_submodule and
+                ((repo_path is not None) or tag or ref_hash or branch)):
+            printlog('create_section: "from_submodule" is incompatible with '
+                     '"repo_url", "tag", "hash", and "branch" options;\n'
+                     'Ignoring those options for {}'.format(name))
+            repo_url = None
+            tag = ''
+            ref_hash = ''
+            branch = ''
+
+        if repo_path is not None:
+            repo_url = repo_path
+        else:
+            repo_url = os.path.join('${MANIC_TEST_BARE_REPO_ROOT}', repo_type)
+
+        if not from_submodule:
+            self._config.set(name, ExternalsDescription.REPO_URL, repo_url)
 
         self._config.set(name, ExternalsDescription.REQUIRED, str(required))
 
@@ -267,6 +286,9 @@ class GenerateExternalsDescriptionCfgV1(object):
 
         if externals:
             self._config.set(name, ExternalsDescription.EXTERNALS, externals)
+
+        if from_submodule:
+            self._config.set(name, ExternalsDescription.SUBMODULE, "True")
 
     def create_section_ext_only(self, name,
                                 required=True, externals=CFG_SUB_NAME):
@@ -377,7 +399,7 @@ class GenerateExternalsDescriptionCfgV1(object):
         except BaseException:
             pass
 
-        self._write_config(dest_dir, filename)
+        self.write_config(dest_dir, filename)
 
     def update_svn_branch(self, dest_dir, name, branch, filename=CFG_NAME):
         """Update a repository branch, and potentially the remote.
@@ -391,7 +413,7 @@ class GenerateExternalsDescriptionCfgV1(object):
         except BaseException:
             pass
 
-        self._write_config(dest_dir, filename)
+        self.write_config(dest_dir, filename)
 
     def update_tag(self, dest_dir, name, tag, repo_type=None,
                    filename=CFG_NAME, remove_branch=True):
@@ -416,7 +438,7 @@ class GenerateExternalsDescriptionCfgV1(object):
         except BaseException:
             pass
 
-        self._write_config(dest_dir, filename)
+        self.write_config(dest_dir, filename)
 
     def update_underspecify_branch_tag(self, dest_dir, name,
                                        filename=CFG_NAME):
@@ -435,7 +457,7 @@ class GenerateExternalsDescriptionCfgV1(object):
         except BaseException:
             pass
 
-        self._write_config(dest_dir, filename)
+        self.write_config(dest_dir, filename)
 
     def update_underspecify_remove_url(self, dest_dir, name,
                                        filename=CFG_NAME):
@@ -448,7 +470,7 @@ class GenerateExternalsDescriptionCfgV1(object):
         except BaseException:
             pass
 
-        self._write_config(dest_dir, filename)
+        self.write_config(dest_dir, filename)
 
     def update_protocol(self, dest_dir, name, protocol, repo_type=None,
                         filename=CFG_NAME):
@@ -461,7 +483,7 @@ class GenerateExternalsDescriptionCfgV1(object):
             repo_url = os.path.join('${MANIC_TEST_BARE_REPO_ROOT}', repo_type)
             self._config.set(name, ExternalsDescription.REPO_URL, repo_url)
 
-        self._write_config(dest_dir, filename)
+        self.write_config(dest_dir, filename)
 
 
 class BaseTestSysCheckout(unittest.TestCase):
@@ -513,7 +535,7 @@ class BaseTestSysCheckout(unittest.TestCase):
         # return to our common starting point
         os.chdir(self._return_dir)
 
-    def setup_test_repo(self, parent_repo_name):
+    def setup_test_repo(self, parent_repo_name, dest_dir_in=None):
         """Setup the paths and clone the base test repo
 
         """
@@ -522,10 +544,14 @@ class BaseTestSysCheckout(unittest.TestCase):
         print("Test repository name: {0}".format(test_dir_name))
 
         parent_repo_dir = os.path.join(self._bare_root, parent_repo_name)
-        dest_dir = os.path.join(os.environ[MANIC_TEST_TMP_REPO_ROOT],
-                                test_dir_name)
+        if dest_dir_in is None:
+            dest_dir = os.path.join(os.environ[MANIC_TEST_TMP_REPO_ROOT],
+                                    test_dir_name)
+        else:
+            dest_dir = dest_dir_in
+
         # pylint: disable=W0212
-        GitRepository._git_clone(parent_repo_dir, dest_dir, VERBOSITY_DEFAULT)
+        GitRepository._git_clone(parent_repo_dir, dest_dir, VERBOSITY_DEFAULT, False)
         return dest_dir
 
     @staticmethod
@@ -1434,6 +1460,237 @@ class TestSysCheckoutSVN(BaseTestSysCheckout):
                                                 self.verbose_args)
         self._check_container_simple_svn_post_checkout(overall, tree)
 
+class TestSubrepoCheckout(BaseTestSysCheckout):
+    # Need to store information at setUp time for checking
+    # pylint: disable=too-many-instance-attributes
+    """Run tests to ensure proper handling of repos with submodules.
+
+    By default, submodules in git repositories are checked out. A git
+    repository checked out as a submodule is treated as if it was
+    listed in an external with the same properties as in the source
+    .gitmodules file.
+    """
+
+    def setUp(self):
+        """Setup for all submodule checkout tests
+        Create a repo with two submodule repositories.
+        """
+
+        # Run the basic setup
+        super(TestSubrepoCheckout, self).setUp()
+        # create test repo
+        # We need to do this here (rather than have a static repo) because
+        # git submodules do not allow for variables in .gitmodules files
+        self._test_repo_name = 'test_repo_with_submodules'
+        self._bare_branch_name = 'subrepo_branch'
+        self._config_branch_name = 'subrepo_config_branch'
+        self._container_extern_name = 'externals_container.cfg'
+        self._my_test_dir = os.path.join(os.environ[MANIC_TEST_TMP_REPO_ROOT],
+                                         self._test_id)
+        self._repo_dir = os.path.join(self._my_test_dir, self._test_repo_name)
+        self._checkout_dir = 'repo_with_submodules'
+        check_dir = self.setup_test_repo(CONTAINER_REPO_NAME,
+                                         dest_dir_in=self._repo_dir)
+        self.assertTrue(self._repo_dir == check_dir)
+        # Add the submodules
+        cwd = os.getcwd()
+        fork_repo_dir = os.path.join(self._bare_root, SIMPLE_FORK_NAME)
+        simple_repo_dir = os.path.join(self._bare_root, SIMPLE_REPO_NAME)
+        self._simple_ext_fork_name = SIMPLE_FORK_NAME.split('.')[0]
+        self._simple_ext_name = SIMPLE_REPO_NAME.split('.')[0]
+        os.chdir(self._repo_dir)
+        # Add a branch with a subrepo
+        cmd = ['git', 'branch', self._bare_branch_name, 'master']
+        execute_subprocess(cmd)
+        cmd = ['git', 'checkout', self._bare_branch_name]
+        execute_subprocess(cmd)
+        cmd = ['git', 'submodule', 'add', fork_repo_dir]
+        execute_subprocess(cmd)
+        cmd = ['git', 'commit', '-am', "'Added simple-ext-fork as a submodule'"]
+        execute_subprocess(cmd)
+        # Save the fork repo hash for comparison
+        os.chdir(self._simple_ext_fork_name)
+        self._fork_hash_check = self.get_git_hash()
+        os.chdir(self._repo_dir)
+        # Now, create a branch to test from_sbmodule
+        cmd = ['git', 'branch',
+               self._config_branch_name, self._bare_branch_name]
+        execute_subprocess(cmd)
+        cmd = ['git', 'checkout', self._config_branch_name]
+        execute_subprocess(cmd)
+        cmd = ['git', 'submodule', 'add', simple_repo_dir]
+        execute_subprocess(cmd)
+        # Checkout feature2
+        os.chdir(self._simple_ext_name)
+        cmd = ['git', 'branch', 'feature2', 'origin/feature2']
+        execute_subprocess(cmd)
+        cmd = ['git', 'checkout', 'feature2']
+        execute_subprocess(cmd)
+        # Save the fork repo hash for comparison
+        self._simple_hash_check = self.get_git_hash()
+        os.chdir(self._repo_dir)
+        self.create_externals_file(filename=self._container_extern_name,
+                                   dest_dir=self._repo_dir, from_submodule=True)
+        cmd = ['git', 'add', self._container_extern_name]
+        execute_subprocess(cmd)
+        cmd = ['git', 'commit', '-am', "'Added simple-ext as a submodule'"]
+        execute_subprocess(cmd)
+        # Reset to master
+        cmd = ['git', 'checkout', 'master']
+        execute_subprocess(cmd)
+        os.chdir(cwd)
+
+    @staticmethod
+    def get_git_hash(revision="HEAD"):
+        """Return the hash for <revision>"""
+        cmd = ['git', 'rev-parse', revision]
+        git_out = execute_subprocess(cmd, output_to_caller=True)
+        return git_out.strip()
+
+    def create_externals_file(self, name='', filename=CFG_NAME, dest_dir=None,
+                              branch_name=None, sub_externals=None,
+                              from_submodule=False):
+        # pylint: disable=too-many-arguments
+        """Create a container externals file with only simple externals.
+
+        """
+        self._generator.create_config()
+
+        if dest_dir is None:
+            dest_dir = self._my_test_dir
+
+        if from_submodule:
+            self._generator.create_section(SIMPLE_FORK_NAME,
+                                           self._simple_ext_fork_name,
+                                           from_submodule=True)
+            self._generator.create_section(SIMPLE_REPO_NAME,
+                                           self._simple_ext_name,
+                                           branch='feature3', path='',
+                                           from_submodule=False)
+        else:
+            if branch_name is None:
+                branch_name = 'master'
+
+            self._generator.create_section(self._test_repo_name,
+                                           self._checkout_dir,
+                                           branch=branch_name,
+                                           path=name, externals=sub_externals,
+                                           repo_path=self._repo_dir)
+
+        self._generator.write_config(dest_dir, filename=filename)
+
+    def idempotence_check(self, checkout_dir):
+        """Verify that calling checkout_externals and
+        checkout_externals --status does not cause errors"""
+        cwd = os.getcwd()
+        os.chdir(checkout_dir)
+        overall, _ = self.execute_cmd_in_dir(self._my_test_dir,
+                                             self.checkout_args)
+        self.assertTrue(overall == 0)
+        overall, _ = self.execute_cmd_in_dir(self._my_test_dir,
+                                             self.status_args)
+        self.assertTrue(overall == 0)
+        os.chdir(cwd)
+
+    def test_submodule_checkout_bare(self):
+        """Verify that a git repo with submodule is properly checked out
+        This test if for where there is no 'externals' keyword in the
+        parent repo.
+        Correct behavior is that the submodule is checked out using
+        normal git submodule behavior.
+        """
+        simple_ext_fork_tag = "(tag1)"
+        simple_ext_fork_status = " "
+        self.create_externals_file(branch_name=self._bare_branch_name)
+        overall, _ = self.execute_cmd_in_dir(self._my_test_dir,
+                                             self.checkout_args)
+        self.assertTrue(overall == 0)
+        cwd = os.getcwd()
+        checkout_dir = os.path.join(self._my_test_dir, self._checkout_dir)
+        fork_file = os.path.join(checkout_dir,
+                                 self._simple_ext_fork_name, "readme.txt")
+        self.assertTrue(os.path.exists(fork_file))
+        os.chdir(checkout_dir)
+        submods = git_submodule_status(checkout_dir)
+        self.assertEqual(len(submods.keys()), 1)
+        self.assertTrue(self._simple_ext_fork_name in submods)
+        submod = submods[self._simple_ext_fork_name]
+        self.assertTrue('hash' in submod)
+        self.assertEqual(submod['hash'], self._fork_hash_check)
+        self.assertTrue('status' in submod)
+        self.assertEqual(submod['status'], simple_ext_fork_status)
+        self.assertTrue('tag' in submod)
+        self.assertEqual(submod['tag'], simple_ext_fork_tag)
+        os.chdir(cwd)
+        self.idempotence_check(checkout_dir)
+
+    def test_submodule_checkout_none(self):
+        """Verify that a git repo with submodule is properly checked out
+        This test is for when 'externals=None' is in parent repo's
+        externals cfg file.
+        Correct behavior is the submodle is not checked out.
+        """
+        self.create_externals_file(branch_name=self._bare_branch_name,
+                                   sub_externals="none")
+        overall, _ = self.execute_cmd_in_dir(self._my_test_dir,
+                                             self.checkout_args)
+        self.assertTrue(overall == 0)
+        cwd = os.getcwd()
+        checkout_dir = os.path.join(self._my_test_dir, self._checkout_dir)
+        fork_file = os.path.join(checkout_dir,
+                                 self._simple_ext_fork_name, "readme.txt")
+        self.assertFalse(os.path.exists(fork_file))
+        os.chdir(cwd)
+        self.idempotence_check(checkout_dir)
+
+    def test_submodule_checkout_config(self): # pylint: disable=too-many-locals
+        """Verify that a git repo with submodule is properly checked out
+        This test if for when the 'from_submodule' keyword is used in the
+        parent repo.
+        Correct behavior is that the submodule is checked out using
+        normal git submodule behavior.
+        """
+        tag_check = None # Not checked out as submodule
+        status_check = "-" # Not checked out as submodule
+        self.create_externals_file(branch_name=self._config_branch_name,
+                                   sub_externals=self._container_extern_name)
+        overall, _ = self.execute_cmd_in_dir(self._my_test_dir,
+                                             self.checkout_args)
+        self.assertTrue(overall == 0)
+        cwd = os.getcwd()
+        checkout_dir = os.path.join(self._my_test_dir, self._checkout_dir)
+        fork_file = os.path.join(checkout_dir,
+                                 self._simple_ext_fork_name, "readme.txt")
+        self.assertTrue(os.path.exists(fork_file))
+        os.chdir(checkout_dir)
+        # Check submodule status
+        submods = git_submodule_status(checkout_dir)
+        self.assertEqual(len(submods.keys()), 2)
+        self.assertTrue(self._simple_ext_fork_name in submods)
+        submod = submods[self._simple_ext_fork_name]
+        self.assertTrue('hash' in submod)
+        self.assertEqual(submod['hash'], self._fork_hash_check)
+        self.assertTrue('status' in submod)
+        self.assertEqual(submod['status'], status_check)
+        self.assertTrue('tag' in submod)
+        self.assertEqual(submod['tag'], tag_check)
+        self.assertTrue(self._simple_ext_name in submods)
+        submod = submods[self._simple_ext_name]
+        self.assertTrue('hash' in submod)
+        self.assertEqual(submod['hash'], self._simple_hash_check)
+        self.assertTrue('status' in submod)
+        self.assertEqual(submod['status'], status_check)
+        self.assertTrue('tag' in submod)
+        self.assertEqual(submod['tag'], tag_check)
+        # Check fork repo status
+        os.chdir(self._simple_ext_fork_name)
+        self.assertEqual(self.get_git_hash(), self._fork_hash_check)
+        os.chdir(checkout_dir)
+        os.chdir(self._simple_ext_name)
+        hash_check = self.get_git_hash('origin/feature3')
+        self.assertEqual(self.get_git_hash(), hash_check)
+        os.chdir(cwd)
+        self.idempotence_check(checkout_dir)
 
 class TestSysCheckoutErrors(BaseTestSysCheckout):
     """Run systems level tests of error conditions in checkout_externals

--- a/test/test_unit_externals_description.py
+++ b/test/test_unit_externals_description.py
@@ -316,11 +316,13 @@ class TestCreateExternalsDescription(unittest.TestCase):
         """Create config object used as basis for all tests
         """
         self._config = config_parser()
+        self._gmconfig = config_parser()
         self.setup_config()
 
     def setup_config(self):
         """Boiler plate construction of xml string for componet 1
         """
+        # Create a standard externals config with a single external
         name = 'test'
         self._config.add_section(name)
         self._config.set(name, ExternalsDescription.PATH, 'externals')
@@ -331,6 +333,14 @@ class TestCreateExternalsDescription(unittest.TestCase):
 
         self._config.add_section(DESCRIPTION_SECTION)
         self._config.set(DESCRIPTION_SECTION, VERSION_ITEM, '1.0.0')
+
+        # Create a .gitmodules test
+        name = 'submodule "gitmodules_test"'
+        self._gmconfig.add_section(name)
+        self._gmconfig.set(name, "path", 'externals/test')
+        self._gmconfig.set(name, "url", '/path/to/repo')
+        # NOTE(goldy, 2019-03) Should test other possible keywords such as
+        # fetchRecurseSubmodules, ignore, and shallow
 
     def test_cfg_v1_ok(self):
         """Test that a correct cfg v1 object is created by create_externals_description
@@ -356,7 +366,7 @@ class TestCreateExternalsDescription(unittest.TestCase):
         rdata = {ExternalsDescription.PROTOCOL: 'git',
                  ExternalsDescription.REPO_URL: '/path/to/repo',
                  ExternalsDescription.TAG: 'tagv1',
-                 }
+                }
 
         desc = {
             'test': {


### PR DESCRIPTION
New capability to use git submodule info to checkout externals

By default, an external with no specified sub-externals configuration file will
have its submodules checked out according to the information in that repository's
.gitmodules file. This process is recursive.

To prevent submodules from being checked out, the external description for that
repository should be listed as "externals = none".

To use submodule URL, local path, and reference hash information for a
sub-external, replace the 'local_path', 'repo_url', and 'branch' 'hash' or 'tag'
keywords with "from_submodule = True".

User interface changes?: Yes 
externals keyword can be "none" to prevent loading submodules.
from_submodule keyword can be used to replace external configuration information
with information from a repository's submodule configuration.

Fixes: #96 

Testing:
  test removed: none
  unit tests: all pass
  system tests: all pass, added TestSubrepoCheckout to test new functionality
  manual testing: Tests with ESCOMP/MOM_interface (see below)
 1) Just run checkout_externals: no change
 2) Remove "externals = ../Externals_MOM.cfg" from Externals.cfg: All four submodules
     of MOM6 checked out
 3) Set "externals = none" in Externals.cfg: No submodules checked out (empty directories)
 4) Modify da_hooks external in Externals_MOM.cfg (see below): da_hooks is checked out with
     MOM6 .gitmodules configuration.
```
[pkg/MOM6_DA_hooks]
protocol = git
from_submodule = True
required = True
```