### PR TITLE
Fixes #120 - support for git sparse checkout via git read-tree.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The root of the source tree will be referred to as `${SRC_ROOT}` below.
     description file:
 
         $ cd ${SRC_ROOT}
-        $ ./manage_externals/checkout_externals --excernals my-externals.cfg
+        $ ./manage_externals/checkout_externals --externals my-externals.cfg
 
   * Status summary of the repositories managed by checkout_externals:
 

--- a/manic/externals_description.py
+++ b/manic/externals_description.py
@@ -351,6 +351,7 @@ class ExternalsDescription(dict):
     REPO_URL = 'repo_url'
     REQUIRED = 'required'
     TAG = 'tag'
+    SPARSE = 'sparse'
 
     PROTOCOL_EXTERNALS_ONLY = 'externals_only'
     PROTOCOL_GIT = 'git'
@@ -374,6 +375,7 @@ class ExternalsDescription(dict):
                              TAG: 'string',
                              BRANCH: 'string',
                              HASH: 'string',
+                             SPARSE: 'string',
                             }
                      }
 
@@ -562,6 +564,8 @@ class ExternalsDescription(dict):
                 self[field][self.REPO][self.HASH] = EMPTY_STR
             if self.REPO_URL not in self[field][self.REPO]:
                 self[field][self.REPO][self.REPO_URL] = EMPTY_STR
+            if self.SPARSE not in self[field][self.REPO]:
+                self[field][self.REPO][self.SPARSE] = EMPTY_STR
 
             # from_submodule has a complex relationship with other fields
             if self.SUBMODULE in self[field]:

--- a/manic/repository.py
+++ b/manic/repository.py
@@ -21,6 +21,7 @@ class Repository(object):
         self._branch = repo[ExternalsDescription.BRANCH]
         self._hash = repo[ExternalsDescription.HASH]
         self._url = repo[ExternalsDescription.REPO_URL]
+        self._sparse = repo[ExternalsDescription.SPARSE]
 
         if self._url is EMPTY_STR:
             fatal_error('repo must have a URL')

--- a/manic/repository_git.py
+++ b/manic/repository_git.py
@@ -316,7 +316,10 @@ class GitRepository(Repository):
         else:
             self._checkout_external_ref(verbosity, submodules)
 
+        if self._sparse:
+            self._sparse_checkout(repo_dir, verbosity)
         os.chdir(cwd)
+
 
     def _checkout_local_ref(self, verbosity, submodules):
         """Checkout the reference considering the local repo only. Do not
@@ -361,6 +364,19 @@ class GitRepository(Repository):
         if self._branch:
             ref = '{0}/{1}'.format(remote_name, ref)
         self._git_checkout_ref(ref, verbosity, submodules)
+
+    def _sparse_checkout(self, repo_dir, verbosity):
+        """Use git read-tree to thin the working tree."""
+        cwd = os.getcwd()
+
+        cmd = ['cp', self._sparse, os.path.join(repo_dir, '.git/info/sparse-checkout')]
+        if verbosity >= VERBOSITY_VERBOSE:
+            printlog('    {0}'.format(' '.join(cmd)))
+        execute_subprocess(cmd)
+        os.chdir(repo_dir)
+        self._git_sparse_checkout(verbosity)
+
+        os.chdir(cwd)
 
     def _check_for_valid_ref(self, ref, remote_name=None):
         """Try some basic sanity checks on the user supplied reference so we
@@ -775,6 +791,18 @@ class GitRepository(Repository):
         execute_subprocess(cmd)
         if submodules:
             GitRepository._git_update_submodules(verbosity)
+
+    @staticmethod
+    def _git_sparse_checkout(verbosity):
+        """Configure repo via read-tree."""
+        cmd = ['git', 'config', 'core.sparsecheckout', 'true']
+        if verbosity >= VERBOSITY_VERBOSE:
+            printlog('    {0}'.format(' '.join(cmd)))
+        execute_subprocess(cmd)
+        cmd = ['git', 'read-tree', '-mu', 'HEAD']
+        if verbosity >= VERBOSITY_VERBOSE:
+            printlog('    {0}'.format(' '.join(cmd)))
+        execute_subprocess(cmd)
 
     @staticmethod
     def _git_update_submodules(verbosity):

--- a/manic/sourcetree.py
+++ b/manic/sourcetree.py
@@ -45,6 +45,7 @@ class _External(object):
         self._externals = EMPTY_STR
         self._externals_sourcetree = None
         self._stat = ExternalStatus()
+        self._sparse = None
         # Parse the sub-elements
 
         # _path : local path relative to the containing source tree

--- a/test/test_unit_repository.py
+++ b/test/test_unit_repository.py
@@ -36,7 +36,8 @@ class TestCreateRepositoryDict(unittest.TestCase):
                       ExternalsDescription.REPO_URL: 'junk_root',
                       ExternalsDescription.TAG: 'junk_tag',
                       ExternalsDescription.BRANCH: EMPTY_STR,
-                      ExternalsDescription.HASH: EMPTY_STR, }
+                      ExternalsDescription.HASH: EMPTY_STR,
+                      ExternalsDescription.SPARSE: EMPTY_STR, }
 
     def test_create_repo_git(self):
         """Verify that several possible names for the 'git' protocol
@@ -95,7 +96,8 @@ class TestRepository(unittest.TestCase):
                      ExternalsDescription.REPO_URL: url,
                      ExternalsDescription.TAG: tag,
                      ExternalsDescription.BRANCH: EMPTY_STR,
-                     ExternalsDescription.HASH: EMPTY_STR, }
+                     ExternalsDescription.HASH: EMPTY_STR,
+                     ExternalsDescription.SPARSE: EMPTY_STR, }
         repo = Repository(name, repo_info)
         print(repo.__dict__)
         self.assertEqual(repo.tag(), tag)
@@ -112,7 +114,8 @@ class TestRepository(unittest.TestCase):
                      ExternalsDescription.REPO_URL: url,
                      ExternalsDescription.BRANCH: branch,
                      ExternalsDescription.TAG: EMPTY_STR,
-                     ExternalsDescription.HASH: EMPTY_STR, }
+                     ExternalsDescription.HASH: EMPTY_STR,
+                     ExternalsDescription.SPARSE: EMPTY_STR, }
         repo = Repository(name, repo_info)
         print(repo.__dict__)
         self.assertEqual(repo.branch(), branch)
@@ -125,11 +128,13 @@ class TestRepository(unittest.TestCase):
         protocol = 'test_protocol'
         url = 'test_url'
         ref = 'deadc0de'
+        sparse = EMPTY_STR
         repo_info = {ExternalsDescription.PROTOCOL: protocol,
                      ExternalsDescription.REPO_URL: url,
                      ExternalsDescription.BRANCH: EMPTY_STR,
                      ExternalsDescription.TAG: EMPTY_STR,
-                     ExternalsDescription.HASH: ref, }
+                     ExternalsDescription.HASH: ref,
+                     ExternalsDescription.SPARSE: sparse, }
         repo = Repository(name, repo_info)
         print(repo.__dict__)
         self.assertEqual(repo.hash(), ref)
@@ -146,11 +151,13 @@ class TestRepository(unittest.TestCase):
         branch = 'test_branch'
         tag = 'test_tag'
         ref = EMPTY_STR
+        sparse = EMPTY_STR
         repo_info = {ExternalsDescription.PROTOCOL: protocol,
                      ExternalsDescription.REPO_URL: url,
                      ExternalsDescription.BRANCH: branch,
                      ExternalsDescription.TAG: tag,
-                     ExternalsDescription.HASH: ref, }
+                     ExternalsDescription.HASH: ref,
+                     ExternalsDescription.SPARSE: sparse, }
         with self.assertRaises(RuntimeError):
             Repository(name, repo_info)
 
@@ -165,11 +172,13 @@ class TestRepository(unittest.TestCase):
         branch = 'test_branch'
         tag = 'test_tag'
         ref = 'deadc0de'
+        sparse = EMPTY_STR
         repo_info = {ExternalsDescription.PROTOCOL: protocol,
                      ExternalsDescription.REPO_URL: url,
                      ExternalsDescription.BRANCH: branch,
                      ExternalsDescription.TAG: tag,
-                     ExternalsDescription.HASH: ref, }
+                     ExternalsDescription.HASH: ref,
+                     ExternalsDescription.SPARSE: sparse, }
         with self.assertRaises(RuntimeError):
             Repository(name, repo_info)
 
@@ -184,11 +193,13 @@ class TestRepository(unittest.TestCase):
         branch = EMPTY_STR
         tag = EMPTY_STR
         ref = EMPTY_STR
+        sparse = EMPTY_STR
         repo_info = {ExternalsDescription.PROTOCOL: protocol,
                      ExternalsDescription.REPO_URL: url,
                      ExternalsDescription.BRANCH: branch,
                      ExternalsDescription.TAG: tag,
-                     ExternalsDescription.HASH: ref, }
+                     ExternalsDescription.HASH: ref,
+                     ExternalsDescription.SPARSE: sparse, }
         with self.assertRaises(RuntimeError):
             Repository(name, repo_info)
 

--- a/test/test_unit_repository_git.py
+++ b/test/test_unit_repository_git.py
@@ -547,7 +547,8 @@ class TestGitCreateRemoteName(unittest.TestCase):
                        ExternalsDescription.TAG:
                        'very_useful_tag',
                        ExternalsDescription.BRANCH: EMPTY_STR,
-                       ExternalsDescription.HASH: EMPTY_STR, }
+                       ExternalsDescription.HASH: EMPTY_STR,
+                       ExternalsDescription.SPARSE: EMPTY_STR, }
         self._repo = GitRepository('test', self._rdata)
 
     def test_remote_git_proto(self):


### PR DESCRIPTION
Config for repo now has an optional entry 'sparse' which only has an
effect for git repositories.  The value is the name of the file
(relative to the parent repo) to be used for sparsification.

* Updated tests to reflect new config key.

  Note: No tests were added for Git sparse checokout.  Existing tests
  were simply updated to ensure that a field entry for sparse was
  available in all relevant tests.

[ 50 character, one line summary ]

[ Description of the changes in this commit. It should be enough
  information for someone not following this development to understand. 
  Lines should be wrapped at about 72 characters. ]

User interface changes?: [ No/Yes ]
[ If yes, describe what changed, and steps taken to ensure backward compatibilty ]

Fixes: [Github issue #s] And brief description of each issue.

Testing:
  test removed:
  unit tests:
  system tests:
  manual testing:

