### PR TITLE
support for internal git repositories

### DIFF
--- a/manic/externals_description.py
+++ b/manic/externals_description.py
@@ -352,6 +352,8 @@ class ExternalsDescription(dict):
     REQUIRED = 'required'
     TAG = 'tag'
     SPARSE = 'sparse'
+    PORT = 'port'
+    USER_NAME = 'user_name'
 
     PROTOCOL_EXTERNALS_ONLY = 'externals_only'
     PROTOCOL_GIT = 'git'
@@ -376,6 +378,8 @@ class ExternalsDescription(dict):
                              BRANCH: 'string',
                              HASH: 'string',
                              SPARSE: 'string',
+                             PORT: 'string',
+                             USER_NAME: 'string',
                             }
                      }
 
@@ -566,6 +570,10 @@ class ExternalsDescription(dict):
                 self[field][self.REPO][self.REPO_URL] = EMPTY_STR
             if self.SPARSE not in self[field][self.REPO]:
                 self[field][self.REPO][self.SPARSE] = EMPTY_STR
+            if self.PORT not in self[field][self.REPO]:
+                self[field][self.REPO][self.PORT] = EMPTY_STR
+            if self.USER_NAME not in self[field][self.REPO]:
+                self[field][self.REPO][self.USER_NAME] = EMPTY_STR
 
             # from_submodule has a complex relationship with other fields
             if self.SUBMODULE in self[field]:

--- a/manic/repository.py
+++ b/manic/repository.py
@@ -39,6 +39,8 @@ class Repository(object):
             git_author_name = os.getenv('GIT_AUTHOR_NAME')
             if not git_author_name == None:
                  self._user_name = git_author_name
+            else:
+                 self._user_name = EMPTY_STR
 
         ref_count = 0
         if self._tag is not EMPTY_STR:

--- a/manic/repository.py
+++ b/manic/repository.py
@@ -1,6 +1,8 @@
 """Base class representation of a repository
 """
 
+import os
+
 from .externals_description import ExternalsDescription
 from .utils import fatal_error
 from .global_constants import EMPTY_STR
@@ -22,6 +24,8 @@ class Repository(object):
         self._hash = repo[ExternalsDescription.HASH]
         self._url = repo[ExternalsDescription.REPO_URL]
         self._sparse = repo[ExternalsDescription.SPARSE]
+        self._port = repo[ExternalsDescription.PORT]
+        self._user_name = repo[ExternalsDescription.USER_NAME]
 
         if self._url is EMPTY_STR:
             fatal_error('repo must have a URL')
@@ -29,6 +33,12 @@ class Repository(object):
         if ((self._tag is EMPTY_STR) and (self._branch is EMPTY_STR) and
                 (self._hash is EMPTY_STR)):
             fatal_error('{0} repo must have a branch, tag or hash element')
+
+        if self._user_name.lower() == 'GIT_AUTHOR_NAME'.lower():
+            # check GIT_AUTHOR_NAME environment variable
+            git_author_name = os.getenv('GIT_AUTHOR_NAME')
+            if not git_author_name == None:
+                 self._user_name = git_author_name
 
         ref_count = 0
         if self._tag is not EMPTY_STR:

--- a/manic/repository.py
+++ b/manic/repository.py
@@ -12,6 +12,8 @@ class Repository(object):
     """
     Class to represent and operate on a repository description.
     """
+    # pylint: disable=too-many-instance-attributes
+    # Nine is reasonable in this case.
 
     def __init__(self, component_name, repo):
         """
@@ -37,10 +39,10 @@ class Repository(object):
         if self._user_name.lower() == 'GIT_AUTHOR_NAME'.lower():
             # check GIT_AUTHOR_NAME environment variable
             git_author_name = os.getenv('GIT_AUTHOR_NAME')
-            if not git_author_name == None:
-                 self._user_name = git_author_name
+            if not git_author_name is None:
+                self._user_name = git_author_name
             else:
-                 self._user_name = EMPTY_STR
+                self._user_name = EMPTY_STR
 
         ref_count = 0
         if self._tag is not EMPTY_STR:

--- a/manic/repository_git.py
+++ b/manic/repository_git.py
@@ -749,7 +749,6 @@ class GitRepository(Repository):
     # system call to git for sideffects modifying the working tree
     #
     # ----------------------------------------------------------------
-    @staticmethod
     def _git_clone(self, repo_dir_name, verbosity):
         """Run git clone for the side effect of creating a repository.
         """
@@ -758,15 +757,15 @@ class GitRepository(Repository):
         url = self._url
 
         # add port
-        if not self._port is EMPTY_STR:
-             ind1 = url.find('//')+2
-             ind2 = url[ind1:].find('/')
-             url = url[:ind1+ind2] + ':' + self._port + url[ind1+ind2:]
+        if self._port is not EMPTY_STR:
+            ind1 = url.find('//')+2
+            ind2 = url[ind1:].find('/')
+            url = url[:ind1+ind2] + ':' + self._port + url[ind1+ind2:]
 
         # add user name
-        if not self._user_name is EMPTY_STR:
-             ind1 = url.find('//')+2
-             url = url[:ind1] + self._user_name + '@' + url[ind1:]
+        if self._user_name is not EMPTY_STR:
+            ind1 = url.find('//')+2
+            url = url[:ind1] + self._user_name + '@' + url[ind1:]
 
         cmd.extend([url, repo_dir_name])
         if verbosity >= VERBOSITY_VERBOSE:

--- a/manic/repository_git.py
+++ b/manic/repository_git.py
@@ -103,7 +103,7 @@ class GitRepository(Repository):
         """
         cwd = os.getcwd()
         os.chdir(base_dir_path)
-        self._git_clone(self._url, repo_dir_name, verbosity)
+        self._git_clone(self, repo_dir_name, verbosity)
         os.chdir(cwd)
 
     def _current_ref(self):
@@ -250,7 +250,7 @@ class GitRepository(Repository):
             data = data.split()
             name = data[0].strip()
             url = data[1].strip()
-            if self._url == url:
+            if self._url == url or not self._port is EMPTY_STR:
                 remote_name = name
                 break
         return remote_name
@@ -750,11 +750,23 @@ class GitRepository(Repository):
     #
     # ----------------------------------------------------------------
     @staticmethod
-    def _git_clone(url, repo_dir_name, verbosity):
+    def _git_clone(self, repo_dir_name, verbosity):
         """Run git clone for the side effect of creating a repository.
         """
         cmd = ['git', 'clone', '--quiet']
         subcmd = None
+        url = self._url
+
+        # add port
+        if not self._port is EMPTY_STR:
+             ind1 = url.find('//')+2
+             ind2 = url[ind1:].find('/')
+             url = url[:ind1+ind2] + ':' + self._port + url[ind1+ind2:]
+
+        # add user name
+        if not self._user_name is EMPTY_STR:
+             ind1 = url.find('//')+2
+             url = url[:ind1] + self._user_name + '@' + url[ind1:]
 
         cmd.extend([url, repo_dir_name])
         if verbosity >= VERBOSITY_VERBOSE:

--- a/manic/repository_git.py
+++ b/manic/repository_git.py
@@ -103,7 +103,25 @@ class GitRepository(Repository):
         """
         cwd = os.getcwd()
         os.chdir(base_dir_path)
-        self._git_clone(self, repo_dir_name, verbosity)
+
+        # get url
+        url = self._url
+
+        # add port
+        if self._port is not EMPTY_STR:
+            ind1 = url.find('//')+2
+            ind2 = url[ind1:].find('/')
+            url = url[:ind1+ind2] + ':' + self._port + url[ind1+ind2:]
+
+        # add user name
+        if self._user_name is not EMPTY_STR:
+            ind1 = url.find('//')+2
+            url = url[:ind1] + self._user_name + '@' + url[ind1:]
+
+        # update url
+        self._url = url
+
+        self._git_clone(url, repo_dir_name, verbosity)
         os.chdir(cwd)
 
     def _current_ref(self):
@@ -749,23 +767,12 @@ class GitRepository(Repository):
     # system call to git for sideffects modifying the working tree
     #
     # ----------------------------------------------------------------
-    def _git_clone(self, repo_dir_name, verbosity):
+    @staticmethod
+    def _git_clone(url, repo_dir_name, verbosity):
         """Run git clone for the side effect of creating a repository.
         """
         cmd = ['git', 'clone', '--quiet']
         subcmd = None
-        url = self._url
-
-        # add port
-        if self._port is not EMPTY_STR:
-            ind1 = url.find('//')+2
-            ind2 = url[ind1:].find('/')
-            url = url[:ind1+ind2] + ':' + self._port + url[ind1+ind2:]
-
-        # add user name
-        if self._user_name is not EMPTY_STR:
-            ind1 = url.find('//')+2
-            url = url[:ind1] + self._user_name + '@' + url[ind1:]
 
         cmd.extend([url, repo_dir_name])
         if verbosity >= VERBOSITY_VERBOSE:

--- a/test/test_sys_checkout.py
+++ b/test/test_sys_checkout.py
@@ -576,7 +576,7 @@ class BaseTestSysCheckout(unittest.TestCase):
             dest_dir = dest_dir_in
 
         # pylint: disable=W0212
-        GitRepository._git_clone(parent_repo_dir, dest_dir, VERBOSITY_DEFAULT)
+        GitRepository._git_clone(self, parent_repo_dir, dest_dir, VERBOSITY_DEFAULT)
         return dest_dir
 
     @staticmethod

--- a/test/test_sys_checkout.py
+++ b/test/test_sys_checkout.py
@@ -576,7 +576,7 @@ class BaseTestSysCheckout(unittest.TestCase):
             dest_dir = dest_dir_in
 
         # pylint: disable=W0212
-        GitRepository._git_clone(self, parent_repo_dir, dest_dir, VERBOSITY_DEFAULT)
+        GitRepository._git_clone(parent_repo_dir, dest_dir, VERBOSITY_DEFAULT)
         return dest_dir
 
     @staticmethod

--- a/test/test_unit_repository.py
+++ b/test/test_unit_repository.py
@@ -37,7 +37,9 @@ class TestCreateRepositoryDict(unittest.TestCase):
                       ExternalsDescription.TAG: 'junk_tag',
                       ExternalsDescription.BRANCH: EMPTY_STR,
                       ExternalsDescription.HASH: EMPTY_STR,
-                      ExternalsDescription.SPARSE: EMPTY_STR, }
+                      ExternalsDescription.SPARSE: EMPTY_STR,
+                      ExternalsDescription.PORT: EMPTY_STR,
+                      ExternalsDescription.USER_NAME: EMPTY_STR, }
 
     def test_create_repo_git(self):
         """Verify that several possible names for the 'git' protocol
@@ -97,7 +99,9 @@ class TestRepository(unittest.TestCase):
                      ExternalsDescription.TAG: tag,
                      ExternalsDescription.BRANCH: EMPTY_STR,
                      ExternalsDescription.HASH: EMPTY_STR,
-                     ExternalsDescription.SPARSE: EMPTY_STR, }
+                     ExternalsDescription.SPARSE: EMPTY_STR,
+                     ExternalsDescription.PORT: EMPTY_STR,
+                     ExternalsDescription.USER_NAME: EMPTY_STR, }
         repo = Repository(name, repo_info)
         print(repo.__dict__)
         self.assertEqual(repo.tag(), tag)
@@ -115,7 +119,9 @@ class TestRepository(unittest.TestCase):
                      ExternalsDescription.BRANCH: branch,
                      ExternalsDescription.TAG: EMPTY_STR,
                      ExternalsDescription.HASH: EMPTY_STR,
-                     ExternalsDescription.SPARSE: EMPTY_STR, }
+                     ExternalsDescription.SPARSE: EMPTY_STR,
+                     ExternalsDescription.PORT: EMPTY_STR,
+                     ExternalsDescription.USER_NAME: EMPTY_STR, }
         repo = Repository(name, repo_info)
         print(repo.__dict__)
         self.assertEqual(repo.branch(), branch)
@@ -129,12 +135,16 @@ class TestRepository(unittest.TestCase):
         url = 'test_url'
         ref = 'deadc0de'
         sparse = EMPTY_STR
+        port = EMPTY_STR
+        user_name = EMPTY_STR
         repo_info = {ExternalsDescription.PROTOCOL: protocol,
                      ExternalsDescription.REPO_URL: url,
                      ExternalsDescription.BRANCH: EMPTY_STR,
                      ExternalsDescription.TAG: EMPTY_STR,
                      ExternalsDescription.HASH: ref,
-                     ExternalsDescription.SPARSE: sparse, }
+                     ExternalsDescription.SPARSE: sparse,
+                     ExternalsDescription.PORT: port,
+                     ExternalsDescription.USER_NAME: user_name, }
         repo = Repository(name, repo_info)
         print(repo.__dict__)
         self.assertEqual(repo.hash(), ref)
@@ -152,12 +162,16 @@ class TestRepository(unittest.TestCase):
         tag = 'test_tag'
         ref = EMPTY_STR
         sparse = EMPTY_STR
+        port = EMPTY_STR
+        user_name = EMPTY_STR
         repo_info = {ExternalsDescription.PROTOCOL: protocol,
                      ExternalsDescription.REPO_URL: url,
                      ExternalsDescription.BRANCH: branch,
                      ExternalsDescription.TAG: tag,
                      ExternalsDescription.HASH: ref,
-                     ExternalsDescription.SPARSE: sparse, }
+                     ExternalsDescription.SPARSE: sparse,
+                     ExternalsDescription.PORT: port,
+                     ExternalsDescription.USER_NAME: user_name, }
         with self.assertRaises(RuntimeError):
             Repository(name, repo_info)
 
@@ -173,12 +187,16 @@ class TestRepository(unittest.TestCase):
         tag = 'test_tag'
         ref = 'deadc0de'
         sparse = EMPTY_STR
+        port = EMPTY_STR
+        user_name = EMPTY_STR
         repo_info = {ExternalsDescription.PROTOCOL: protocol,
                      ExternalsDescription.REPO_URL: url,
                      ExternalsDescription.BRANCH: branch,
                      ExternalsDescription.TAG: tag,
                      ExternalsDescription.HASH: ref,
-                     ExternalsDescription.SPARSE: sparse, }
+                     ExternalsDescription.SPARSE: sparse,
+                     ExternalsDescription.PORT: port,
+                     ExternalsDescription.USER_NAME: user_name, }
         with self.assertRaises(RuntimeError):
             Repository(name, repo_info)
 
@@ -194,12 +212,16 @@ class TestRepository(unittest.TestCase):
         tag = EMPTY_STR
         ref = EMPTY_STR
         sparse = EMPTY_STR
+        port = EMPTY_STR
+        user_name = EMPTY_STR
         repo_info = {ExternalsDescription.PROTOCOL: protocol,
                      ExternalsDescription.REPO_URL: url,
                      ExternalsDescription.BRANCH: branch,
                      ExternalsDescription.TAG: tag,
                      ExternalsDescription.HASH: ref,
-                     ExternalsDescription.SPARSE: sparse, }
+                     ExternalsDescription.SPARSE: sparse,
+                     ExternalsDescription.PORT: port,
+                     ExternalsDescription.USER_NAME: user_name, }
         with self.assertRaises(RuntimeError):
             Repository(name, repo_info)
 

--- a/test/test_unit_repository_git.py
+++ b/test/test_unit_repository_git.py
@@ -548,7 +548,9 @@ class TestGitCreateRemoteName(unittest.TestCase):
                        'very_useful_tag',
                        ExternalsDescription.BRANCH: EMPTY_STR,
                        ExternalsDescription.HASH: EMPTY_STR,
-                       ExternalsDescription.SPARSE: EMPTY_STR, }
+                       ExternalsDescription.SPARSE: EMPTY_STR,
+                       ExternalsDescription.PORT: EMPTY_STR,
+                       ExternalsDescription.USER_NAME: EMPTY_STR, }
         self._repo = GitRepository('test', self._rdata)
 
     def test_remote_git_proto(self):


### PR DESCRIPTION
The manage external is mainly used by the UFSCOMP to checkout sub components and we need to checkout FV3GS code from NOAA's internal git repository called Vlab and gerrit to support standalone FV3GFS application. The following is the actuall git command to checkout the code

git clone --quiet ssh://ufuk.turuncoglu@vlab.ncep.noaa.gov:29418/FV3 FV3GFS

but manage_externals confuses when the url contains user name and port. This PR fixes the issue and allows to checkout code from internal git repository.

**Changes:**
* port and user_name are added as a entry to the Externals.cfg
* user_name can be any string and also special word as GIT_AUTHOR_NAME.
* the GIT_AUTHOR_NAME is replaced by the environment variable with same name

User interface changes?: Yes
Externals.cfg now contains two additional field like port and user_name. It is backward compatible and if they are not set empty string will be used to generate url.

Fixes: No

Testing:
  test removed: N/A
  unit tests: N/A
  system tests: N/A
  manual testing: N/A
