### PR TITLE
Fixes for python3.8, and tweak travis-ci testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,3 @@
-# NOTE(bja, 2017-11) travis-ci dosen't support python language builds
-#  on mac os. As a work around, we use built-in python on linux, and
-#  declare osx a 'generic' language, and create our own python env.
-
 language: python
 os: linux
 python: 
@@ -11,17 +7,6 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
-matrix:
-  include:
-  - os: osx
-    language: generic
-    before_install:
-      # NOTE(bja, 2017-11) update is slow, 2.7.12 installed by default, good enough!
-      # - brew update
-      # - brew outdated python2 || brew upgrade python2
-      - pip install virtualenv
-      - virtualenv env -p python2
-      - source env/bin/activate
 install:
   - pip install -r test/requirements.txt
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
+  - "3.8"
 matrix:
   include:
   - os: osx

--- a/manic/repository_svn.py
+++ b/manic/repository_svn.py
@@ -220,9 +220,8 @@ then rerun checkout_externals.
                 continue
             if item == SVN_UNVERSIONED:
                 continue
-            else:
-                is_dirty = True
-                break
+            is_dirty = True
+            break
         return is_dirty
 
     # ----------------------------------------------------------------

--- a/manic/sourcetree.py
+++ b/manic/sourcetree.py
@@ -299,18 +299,20 @@ class SourceTree(object):
         for comp in load_comps:
             printlog('{0}, '.format(comp), end='')
             stat = self._all_components[comp].status()
+            stat_final = {}
             for name in stat.keys():
                 # check if we need to append the relative_path_base to
                 # the path so it will be sorted in the correct order.
-                if not stat[name].path.startswith(relative_path_base):
-                    stat[name].path = os.path.join(relative_path_base,
-                                                   stat[name].path)
-                    # store under key = updated path, and delete the
-                    # old key.
-                    comp_stat = stat[name]
-                    del stat[name]
-                    stat[comp_stat.path] = comp_stat
-            summary.update(stat)
+                if stat[name].path.startswith(relative_path_base):
+                    # use as is, without any changes to path
+                    stat_final[name] = stat[name]
+                else:
+                    # append relative_path_base to path and store under key = updated path
+                    modified_path = os.path.join(relative_path_base,
+                                                 stat[name].path)
+                    stat_final[modified_path] = stat[name]
+                    stat_final[modified_path].path = modified_path
+            summary.update(stat_final)
 
         return summary
 


### PR DESCRIPTION
- Critical fix needed for python3.8
- pylint fix needed for all versions of python 3
- Add python3.7 and python3.8 testing through travis-ci
- Remove travis-ci testing on Mac OS (which was using python2, and was
  failing)

User interface changes?: No

Fixes ESMCI/cime#135 ("dictionary keys changed during iteration" when
running checkout_externals)

Testing: 'make lint', 'make test'
  test removed: travis-ci testing on Mac OS
  unit tests: pass
  system tests: pass
  manual testing:

With these diffs in a CESM checkout:

```diff
diff --git a/Externals.cfg b/Externals.cfg
index b943c25..6b0f03e 100644
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -39,7 +39,7 @@ required = True
 tag = release-cesm2.0.03
 protocol = git
 repo_url = https://github.com/ESCOMP/mosart
-local_path = components/mosart
+local_path = ./components/mosart
 required = True

 [pop]
```

ensured that `manage_externals -S` gives the exact same output now as
before.
