### PR TITLE
ignore this silently, we use a hash so it does not matter

### DIFF
--- a/manic/externals_description.py
+++ b/manic/externals_description.py
@@ -180,6 +180,9 @@ def parse_submodules_desc_section(section_items, file_path):
             path = item[1].strip()
         elif name == 'url':
             url = item[1].strip()
+        elif name == 'branch':
+            # We do not care about branch since we have a hash - silently ignore
+            pass
         else:
             msg = 'WARNING: Ignoring unknown {} property, in {}'
             msg = msg.format(item[0], file_path) # fool pylint


### PR DESCRIPTION
Ignore the branch property of .gitmodules silently since we use hashes.

User interface changes?:  No

Fixes: [Github issue #s] And brief description of each issue.

Testing:
  test removed:
  unit tests:
  system tests:
  manual testing: ran manage externals on repo with git submodules (ufs-weather-app)

