### PR TITLE
add an exclude option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ components/
 
 # generated python files
 *.pyc
+
+# test tmp file
+test/tmp

--- a/manic/checkout.py
+++ b/manic/checkout.py
@@ -280,7 +280,7 @@ of the externals description file or examine the output of
                         'Default: %(default)s.')
 
     parser.add_argument('-x', '--exclude', nargs='*',
-                        help='Component(s) listed in the externals file which should be ignored.' )
+                        help='Component(s) listed in the externals file which should be ignored.')
 
     parser.add_argument('-o', '--optional', action='store_true', default=False,
                         help='By default only the required externals '

--- a/manic/checkout.py
+++ b/manic/checkout.py
@@ -279,6 +279,9 @@ of the externals description file or examine the output of
                         help='The externals description filename. '
                         'Default: %(default)s.')
 
+    parser.add_argument('-x', '--exclude', nargs='*',
+                        help='Component(s) listed in the externals file which should be ignored.' )
+
     parser.add_argument('-o', '--optional', action='store_true', default=False,
                         help='By default only the required externals '
                         'are checked out. This flag will also checkout the '
@@ -362,7 +365,7 @@ def main(args):
     root_dir = os.path.abspath(os.getcwd())
     external_data = read_externals_description_file(root_dir, args.externals)
     external = create_externals_description(
-        external_data, components=args.components)
+        external_data, components=args.components, exclude=args.exclude)
 
     for comp in args.components:
         if comp not in external.keys():

--- a/manic/externals_description.py
+++ b/manic/externals_description.py
@@ -722,11 +722,12 @@ class ExternalsDescriptionDict(ExternalsDescription):
         self._input_patch = 0
         self._verify_schema_version()
         if components:
-            for key in model_data.items():
+            for key in list(model_data.keys()):
                 if key not in components:
                     del model_data[key]
+
         if exclude:
-            for key in model_data.items():
+            for key in list(model_data.keys()):
                 if key in exclude:
                     del model_data[key]
 

--- a/manic/externals_description.py
+++ b/manic/externals_description.py
@@ -264,18 +264,18 @@ def read_gitmodules_file(root_dir, file_name):
     return externals_description
 
 def create_externals_description(
-        model_data, model_format='cfg', components=None, parent_repo=None):
+        model_data, model_format='cfg', components=None, exclude=None, parent_repo=None):
     """Create the a externals description object from the provided data
     """
     externals_description = None
     if model_format == 'dict':
         externals_description = ExternalsDescriptionDict(
-            model_data, components=components)
+            model_data, components=components, exclude=exclude)
     elif model_format == 'cfg':
         major, _, _ = get_cfg_schema_version(model_data)
         if major == 1:
             externals_description = ExternalsDescriptionConfigV1(
-                model_data, components=components, parent_repo=parent_repo)
+                model_data, components=components, exclude=exclude, parent_repo=parent_repo)
         else:
             msg = ('Externals description file has unsupported schema '
                    'version "{0}".'.format(major))
@@ -710,7 +710,7 @@ class ExternalsDescriptionDict(ExternalsDescription):
 
     """
 
-    def __init__(self, model_data, components=None):
+    def __init__(self, model_data, components=None, exclude=None):
         """Parse a native dictionary into a externals description.
         """
         ExternalsDescription.__init__(self)
@@ -725,6 +725,10 @@ class ExternalsDescriptionDict(ExternalsDescription):
             for key in model_data.items():
                 if key not in components:
                     del model_data[key]
+        if exclude:
+            for key in model_data.items():
+                if key in exclude:
+                    del model_data[key]
 
         self.update(model_data)
         self._check_user_input()
@@ -736,7 +740,7 @@ class ExternalsDescriptionConfigV1(ExternalsDescription):
 
     """
 
-    def __init__(self, model_data, components=None, parent_repo=None):
+    def __init__(self, model_data, components=None, exclude=None, parent_repo=None):
         """Convert the config data into a standardized dict that can be used to
         construct the source objects
 
@@ -749,7 +753,7 @@ class ExternalsDescriptionConfigV1(ExternalsDescription):
             get_cfg_schema_version(model_data)
         self._verify_schema_version()
         self._remove_metadata(model_data)
-        self._parse_cfg(model_data, components=components)
+        self._parse_cfg(model_data, components=components, exclude=exclude)
         self._check_user_input()
 
     @staticmethod
@@ -761,7 +765,7 @@ class ExternalsDescriptionConfigV1(ExternalsDescription):
         """
         model_data.remove_section(DESCRIPTION_SECTION)
 
-    def _parse_cfg(self, cfg_data, components=None):
+    def _parse_cfg(self, cfg_data, components=None, exclude=None):
         """Parse a config_parser object into a externals description.
         """
         def list_to_dict(input_list, convert_to_lower_case=True):
@@ -778,7 +782,7 @@ class ExternalsDescriptionConfigV1(ExternalsDescription):
 
         for section in cfg_data.sections():
             name = config_string_cleaner(section.lower().strip())
-            if components and name not in components:
+            if (components and name not in components) or (exclude and name in exclude):
                 continue
             self[name] = {}
             self[name].update(list_to_dict(cfg_data.items(section)))

--- a/test/test_sys_checkout.py
+++ b/test/test_sys_checkout.py
@@ -1362,7 +1362,7 @@ class TestSysCheckout(BaseTestSysCheckout):
         self._generator.container_full(under_test_dir)
 
         # inital checkout, exclude simp_opt
-        checkout_args = ['--exclude','simp_opt', '--logging']
+        checkout_args = ['--exclude', 'simp_opt']
         checkout_args.extend(self.checkout_args)
         overall, tree = self.execute_cmd_in_dir(under_test_dir, checkout_args)
         checkout_args.append("--status")

--- a/test/test_sys_checkout.py
+++ b/test/test_sys_checkout.py
@@ -1361,14 +1361,13 @@ class TestSysCheckout(BaseTestSysCheckout):
         # create the top level externals file
         self._generator.container_full(under_test_dir)
 
-        # inital checkout, first try a nonexistant component argument noref
-        checkout_args = ['--exclude','simp_opt']
+        # inital checkout, exclude simp_opt
+        checkout_args = ['--exclude','simp_opt', '--logging']
         checkout_args.extend(self.checkout_args)
-        save_checkout_args = self.checkout_args
-        self.checkout_args = checkout_args
+        overall, tree = self.execute_cmd_in_dir(under_test_dir, checkout_args)
+        checkout_args.append("--status")
         overall, tree = self.execute_cmd_in_dir(under_test_dir, checkout_args)
         self._check_container_component_post_checkout3(overall, tree)
-        self.checkout_args = save_checkout_args
 
     def test_mixed_simple(self):
         """Verify that a mixed use repo can serve as a 'full' container,

--- a/test/test_sys_checkout.py
+++ b/test/test_sys_checkout.py
@@ -1347,6 +1347,23 @@ class TestSysCheckout(BaseTestSysCheckout):
                                                 self.status_args)
         self._check_container_component_post_checkout2(overall, tree)
 
+    def test_container_exclude_component(self):
+        """Verify that optional component checkout works
+        """
+        # create the test repository
+        under_test_dir = self.setup_test_repo(CONTAINER_REPO_NAME)
+
+        # create the top level externals file
+        self._generator.container_full(under_test_dir)
+
+        # inital checkout, first try a nonexistant component argument noref
+        checkout_args = ['--exclude simp_opt']
+        checkout_args.extend(self.checkout_args)
+
+        overall, tree = self.execute_cmd_in_dir(under_test_dir, checkout_args)
+
+        self._check_container_component_post_checkout2(overall, tree)
+
     def test_mixed_simple(self):
         """Verify that a mixed use repo can serve as a 'full' container,
         pulling in a set of externals and a seperate set of sub-externals.

--- a/test/test_sys_checkout.py
+++ b/test/test_sys_checkout.py
@@ -819,8 +819,13 @@ class BaseTestSysCheckout(unittest.TestCase):
 
     def _check_container_component_post_checkout2(self, overall, tree):
         self.assertEqual(overall, 0)
-        self._check_simple_opt_ok(tree)
         self._check_simple_tag_empty(tree)
+        self._check_simple_branch_ok(tree)
+
+    def _check_container_component_post_checkout3(self, overall, tree):
+        self.assertEqual(overall, 0)
+        self.assertFalse("simp_opt" in tree)
+        self._check_simple_tag_ok(tree)
         self._check_simple_branch_ok(tree)
 
     def _check_container_full_post_checkout(self, overall, tree):
@@ -1348,7 +1353,7 @@ class TestSysCheckout(BaseTestSysCheckout):
         self._check_container_component_post_checkout2(overall, tree)
 
     def test_container_exclude_component(self):
-        """Verify that optional component checkout works
+        """Verify that exclude component checkout works
         """
         # create the test repository
         under_test_dir = self.setup_test_repo(CONTAINER_REPO_NAME)
@@ -1357,12 +1362,13 @@ class TestSysCheckout(BaseTestSysCheckout):
         self._generator.container_full(under_test_dir)
 
         # inital checkout, first try a nonexistant component argument noref
-        checkout_args = ['--exclude simp_opt']
+        checkout_args = ['--exclude','simp_opt']
         checkout_args.extend(self.checkout_args)
-
+        save_checkout_args = self.checkout_args
+        self.checkout_args = checkout_args
         overall, tree = self.execute_cmd_in_dir(under_test_dir, checkout_args)
-
-        self._check_container_component_post_checkout2(overall, tree)
+        self._check_container_component_post_checkout3(overall, tree)
+        self.checkout_args = save_checkout_args
 
     def test_mixed_simple(self):
         """Verify that a mixed use repo can serve as a 'full' container,

--- a/test/test_unit_externals_description.py
+++ b/test/test_unit_externals_description.py
@@ -412,7 +412,7 @@ class TestCreateExternalsDescription(unittest.TestCase):
         ext = create_externals_description(desc, model_format='dict')
         self.assertIsInstance(ext, ExternalsDescriptionDict)
 
-    def test_container_component_dict(self):
+    def test_cfg_component_dict(self):
         """Verify that create_externals_description works with a dictionary
         """
         # create the top level externals file
@@ -425,7 +425,7 @@ class TestCreateExternalsDescription(unittest.TestCase):
         self.assertTrue('simp_opt' in external)
         self.assertTrue('mixed_req' in external)
 
-    def test_container_exclude_component_dict(self):
+    def test_cfg_exclude_component_dict(self):
         """Verify that exclude component checkout works with a dictionary
         """
         # create the top level externals file
@@ -440,7 +440,7 @@ class TestCreateExternalsDescription(unittest.TestCase):
         self.assertFalse('simp_opt' in external)
         self.assertTrue('mixed_req' in external)
 
-    def test_container_opt_component_dict(self):
+    def test_cfg_opt_component_dict(self):
         """Verify that exclude component checkout works with a dictionary
         """
         # create the top level externals file

--- a/test/test_unit_externals_description.py
+++ b/test/test_unit_externals_description.py
@@ -342,7 +342,8 @@ class TestCreateExternalsDescription(unittest.TestCase):
         # NOTE(goldy, 2019-03) Should test other possible keywords such as
         # fetchRecurseSubmodules, ignore, and shallow
 
-    def setup_dict_config(self):
+    @staticmethod
+    def setup_dict_config():
         """Create the full container dictionary with simple and mixed use
         externals
 

--- a/test/test_unit_externals_description.py
+++ b/test/test_unit_externals_description.py
@@ -342,6 +342,39 @@ class TestCreateExternalsDescription(unittest.TestCase):
         # NOTE(goldy, 2019-03) Should test other possible keywords such as
         # fetchRecurseSubmodules, ignore, and shallow
 
+    def setup_dict_config(self):
+        """Create the full container dictionary with simple and mixed use
+        externals
+
+        """
+        rdatat = {ExternalsDescription.PROTOCOL: 'git',
+                  ExternalsDescription.REPO_URL: 'simple-ext.git',
+                  ExternalsDescription.TAG: 'tag1'}
+        rdatab = {ExternalsDescription.PROTOCOL: 'git',
+                  ExternalsDescription.REPO_URL: 'simple-ext.git',
+                  ExternalsDescription.BRANCH: 'feature2'}
+        rdatam = {ExternalsDescription.PROTOCOL: 'git',
+                  ExternalsDescription.REPO_URL: 'mixed-cont-ext.git',
+                  ExternalsDescription.BRANCH: 'master'}
+        desc = {'simp_tag': {ExternalsDescription.REQUIRED: True,
+                             ExternalsDescription.PATH: 'simp_tag',
+                             ExternalsDescription.EXTERNALS: EMPTY_STR,
+                             ExternalsDescription.REPO: rdatat},
+                'simp_branch' : {ExternalsDescription.REQUIRED: True,
+                                 ExternalsDescription.PATH: 'simp_branch',
+                                 ExternalsDescription.EXTERNALS: EMPTY_STR,
+                                 ExternalsDescription.REPO: rdatab},
+                'simp_opt': {ExternalsDescription.REQUIRED: False,
+                             ExternalsDescription.PATH: 'simp_opt',
+                             ExternalsDescription.EXTERNALS: EMPTY_STR,
+                             ExternalsDescription.REPO: rdatat},
+                'mixed_req': {ExternalsDescription.REQUIRED: True,
+                              ExternalsDescription.PATH: 'mixed_req',
+                              ExternalsDescription.EXTERNALS: 'sub-ext.cfg',
+                              ExternalsDescription.REPO: rdatam}}
+
+        return desc
+
     def test_cfg_v1_ok(self):
         """Test that a correct cfg v1 object is created by create_externals_description
 
@@ -378,6 +411,49 @@ class TestCreateExternalsDescription(unittest.TestCase):
 
         ext = create_externals_description(desc, model_format='dict')
         self.assertIsInstance(ext, ExternalsDescriptionDict)
+
+    def test_container_component_dict(self):
+        """Verify that create_externals_description works with a dictionary
+        """
+        # create the top level externals file
+        desc = self.setup_dict_config()
+        # Check external with all repos
+        external = create_externals_description(desc, model_format='dict')
+        self.assertIsInstance(external, ExternalsDescriptionDict)
+        self.assertTrue('simp_tag' in external)
+        self.assertTrue('simp_branch' in external)
+        self.assertTrue('simp_opt' in external)
+        self.assertTrue('mixed_req' in external)
+
+    def test_container_exclude_component_dict(self):
+        """Verify that exclude component checkout works with a dictionary
+        """
+        # create the top level externals file
+        desc = self.setup_dict_config()
+        # Test an excluded repo
+        external = create_externals_description(desc, model_format='dict',
+                                                exclude=['simp_tag',
+                                                         'simp_opt'])
+        self.assertIsInstance(external, ExternalsDescriptionDict)
+        self.assertFalse('simp_tag' in external)
+        self.assertTrue('simp_branch' in external)
+        self.assertFalse('simp_opt' in external)
+        self.assertTrue('mixed_req' in external)
+
+    def test_container_opt_component_dict(self):
+        """Verify that exclude component checkout works with a dictionary
+        """
+        # create the top level externals file
+        desc = self.setup_dict_config()
+        # Test an excluded repo
+        external = create_externals_description(desc, model_format='dict',
+                                                components=['simp_tag',
+                                                            'simp_opt'])
+        self.assertIsInstance(external, ExternalsDescriptionDict)
+        self.assertTrue('simp_tag' in external)
+        self.assertFalse('simp_branch' in external)
+        self.assertTrue('simp_opt' in external)
+        self.assertFalse('mixed_req' in external)
 
     def test_cfg_unknown_version(self):
         """Test that a runtime error is raised when an unknown file version is


### PR DESCRIPTION
add an exclude option (-x name, --exclude name) to ignore component with name and all of it's subcomponents. 

User interface changes?: Yes 
command line option added , fully backward compatible

Fixes: #140  

Testing:
  test removed:
  unit tests:
  system tests:
  manual testing: manually tested -x cam, -x cam pop, -x cam pop mom

