### PR TITLE
Add some details to the error message when externals are modified

### DIFF
--- a/manic/checkout.py
+++ b/manic/checkout.py
@@ -392,7 +392,7 @@ def main(args):
             # exit gracefully
             msg = """The external repositories labeled with 'M' above are not in a clean state.
 
-The following are two options for how to proceed:
+The following are three options for how to proceed:
 
 (1) Go into each external that is not in a clean state and issue either a 'git status' or
     an 'svn status' command (depending on whether the external is managed by git or
@@ -406,6 +406,11 @@ The following are two options for how to proceed:
     configuration file {config_file}. (For example, run 'git fetch' and 'git checkout'
     commands to checkout the appropriate tags for each external, as given in
     {config_file}.)
+
+(3) You can also use {program_name} to manage most, but not all externals: You can specify
+    one or more externals to ignore using the '-x' or '--exclude' argument to
+    {program_name}. Excluding externals labeled with 'M' will allow {program_name} to
+    update the other, non-excluded externals.
 
 
 The external repositories labeled with '?' above are not under version

--- a/manic/checkout.py
+++ b/manic/checkout.py
@@ -394,15 +394,18 @@ def main(args):
 
 The following are two options for how to proceed:
 
-(1) Go into each external that is not in a clean state and issue either
-    an 'svn status' or a 'git status' command. Either revert or commit
-    your changes so that all externals are in a clean state. (Note,
-    though, that it is okay to have untracked files in your working
+(1) Go into each external that is not in a clean state and issue either a 'git status' or
+    an 'svn status' command (depending on whether the external is managed by git or
+    svn). Either revert or commit your changes so that all externals are in a clean
+    state. (To revert changes in git, follow the instructions given when you run 'git
+    status'.) (Note, though, that it is okay to have untracked files in your working
     directory.) Then rerun {program_name}.
 
-(2) Alternatively, you do not have to rely on {program_name}. Instead, you
-    can manually update out-of-sync externals (labeled with 's' above)
-    as described in the configuration file {config_file}.
+(2) Alternatively, you do not have to rely on {program_name}. Instead, you can manually
+    update out-of-sync externals (labeled with 's' above) as described in the
+    configuration file {config_file}. (For example, run 'git fetch' and 'git checkout'
+    commands to checkout the appropriate tags for each external, as given in
+    {config_file}.)
 
 
 The external repositories labeled with '?' above are not under version


### PR DESCRIPTION
Add some details to the error message when externals are modified

A user commented that this error message was unclear, particularly if you don't know how to revert changes in git. This is hopefully a small improvement, at least.

User interface changes?: No

Fixes: None

Testing: `make utest`, `make stest`, `make lint`
  test removed: none
  unit tests: pass
  system tests: pass
  manual testing: examined error message as printed

