### PR TITLE
fix to allow submodule name different from path

### DIFF
--- a/manic/externals_description.py
+++ b/manic/externals_description.py
@@ -253,9 +253,21 @@ def read_gitmodules_file(root_dir, file_name):
                                           ExternalsDescription.REPO_URL, url)
                 externals_description.set(sec_name,
                                           ExternalsDescription.REQUIRED, 'True')
-                git_hash = submods[sec_name]['hash']
-                externals_description.set(sec_name,
-                                          ExternalsDescription.HASH, git_hash)
+                if sec_name in submods:
+                    submod_name = sec_name
+                else:
+                    # The section name does not have to match the path
+                    submod_name = path
+
+                if submod_name in submods:
+                    git_hash = submods[submod_name]['hash']
+                    externals_description.set(sec_name,
+                                              ExternalsDescription.HASH,
+                                              git_hash)
+                else:
+                    emsg = "submodule status has no section, '{}'"
+                    emsg += "\nCheck section names in externals config file"
+                    fatal_error(emsg.format(submod_name))
 
         # Required items
         externals_description.add_section(DESCRIPTION_SECTION)


### PR DESCRIPTION
allow submodule name different from path

Modified collection of submodule information to allow the path to be different from the submodule's name.

User interface changes?: No

Fixes: #149 

Testing:
  test removed: None
  unit tests: All pass
  system tests: Modified one test to reproduce the problem, all pass with the fix
  manual testing: NA

