### PR TITLE
Add prereq option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 os: linux
-python: 
-  - "2.7"
+python:
   - "3.4"
   - "3.5"
   - "3.6"
@@ -13,7 +12,7 @@ before_script:
   - git --version
 script:
   - cd test; make test
-  - cd test; make lint
+  - make lint
 after_success:
   - cd test; make coverage
-  - cd test; coveralls
+  - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_script:
   - git --version
 script:
   - cd test; make test
-  - make lint
+  - cd test; make lint
 after_success:
   - cd test; make coverage
   - coveralls

--- a/manic/checkout.py
+++ b/manic/checkout.py
@@ -380,14 +380,14 @@ def main(args):
 
     if args.status:
         # user requested status-only
-        for comp in sorted(tree_status.keys()):
+        for comp in sorted(tree_status):
             tree_status[comp].log_status_message(args.verbose)
     else:
         # checkout / update the external repositories.
         safe_to_update = check_safe_to_update_repos(tree_status)
         if not safe_to_update:
             # print status
-            for comp in sorted(tree_status.keys()):
+            for comp in sorted(tree_status):
                 tree_status[comp].log_status_message(args.verbose)
             # exit gracefully
             msg = """The external repositories labeled with 'M' above are not in a clean state.

--- a/manic/externals_description.py
+++ b/manic/externals_description.py
@@ -263,6 +263,8 @@ def read_gitmodules_file(root_dir, file_name):
 
     return externals_description
 
+# pylint: disable=R0204
+
 def create_externals_description(
         model_data, model_format='cfg', components=None, exclude=None, parent_repo=None):
 

--- a/manic/externals_description.py
+++ b/manic/externals_description.py
@@ -265,6 +265,7 @@ def read_gitmodules_file(root_dir, file_name):
 
 def create_externals_description(
         model_data, model_format='cfg', components=None, exclude=None, parent_repo=None):
+
     """Create the a externals description object from the provided data
     """
     externals_description = None
@@ -355,6 +356,7 @@ class ExternalsDescription(dict):
     REQUIRED = 'required'
     TAG = 'tag'
     SPARSE = 'sparse'
+    PREREQ = 'prereq'
 
     PROTOCOL_EXTERNALS_ONLY = 'externals_only'
     PROTOCOL_GIT = 'git'
@@ -379,6 +381,7 @@ class ExternalsDescription(dict):
                              BRANCH: 'string',
                              HASH: 'string',
                              SPARSE: 'string',
+                             PREREQ: 'string',
                             }
                      }
 
@@ -388,7 +391,6 @@ class ExternalsDescription(dict):
 
         """
         dict.__init__(self)
-
         self._schema_major = None
         self._schema_minor = None
         self._schema_patch = None
@@ -569,6 +571,8 @@ class ExternalsDescription(dict):
                 self[field][self.REPO][self.REPO_URL] = EMPTY_STR
             if self.SPARSE not in self[field][self.REPO]:
                 self[field][self.REPO][self.SPARSE] = EMPTY_STR
+            if self.PREREQ not in self[field][self.REPO]:
+                self[field][self.REPO][self.PREREQ] = EMPTY_STR
 
             # from_submodule has a complex relationship with other fields
             if self.SUBMODULE in self[field]:
@@ -766,7 +770,7 @@ class ExternalsDescriptionConfigV1(ExternalsDescription):
         """
         model_data.remove_section(DESCRIPTION_SECTION)
 
-    def _parse_cfg(self, cfg_data, components=None, exclude=None):
+    def _parse_cfg(self, cfg_data, components=None):
         """Parse a config_parser object into a externals description.
         """
         def list_to_dict(input_list, convert_to_lower_case=True):

--- a/manic/externals_description.py
+++ b/manic/externals_description.py
@@ -770,7 +770,7 @@ class ExternalsDescriptionConfigV1(ExternalsDescription):
         """
         model_data.remove_section(DESCRIPTION_SECTION)
 
-    def _parse_cfg(self, cfg_data, components=None):
+    def _parse_cfg(self, cfg_data, components=None, exclude=None):
         """Parse a config_parser object into a externals description.
         """
         def list_to_dict(input_list, convert_to_lower_case=True):

--- a/manic/repository_factory.py
+++ b/manic/repository_factory.py
@@ -10,6 +10,7 @@ from .repository_svn import SvnRepository
 from .externals_description import ExternalsDescription
 from .utils import fatal_error
 
+# pylint: disable=R0204
 
 def create_repository(component_name, repo_info, svn_ignore_ancestry=False):
     """Determine what type of repository we have, i.e. git or svn, and

--- a/manic/sourcetree.py
+++ b/manic/sourcetree.py
@@ -323,6 +323,7 @@ class SourceTree(object):
 
         return summary
 
+    # pylint: disable=R0912
     def checkout(self, verbosity, load_all, load_comp=None):
         """
         Checkout or update indicated components into the the configured
@@ -348,15 +349,13 @@ class SourceTree(object):
         for comp in tmp_comps:
             prereq = self._all_components[comp].get_prereq()
             if prereq:
-                if prereq in self._all_components:
-                    if prereq not in load_comps:
-                        load_comps.append(prereq)
-                    load_comps.append(comp)
+                if prereq in self._all_components and prereq not in load_comps:
+                    load_comps.append(prereq)
                 else:
                     fatal_error("prereq {} of component {} not found".format(prereq, comp))
-            else:
-                if comp not in load_comps:
-                    load_comps.append(comp)
+                load_comps.append(comp)
+            elif comp not in load_comps:
+                load_comps.append(comp)
 
         # checkout the primary externals
         for comp in load_comps:

--- a/manic/sourcetree.py
+++ b/manic/sourcetree.py
@@ -363,17 +363,24 @@ class SourceTree(object):
             self._all_components[comp].checkout_externals(verbosity, load_all)
 
     def order_comps_by_prereq(self, comps_in):
+        """
+        put the comps into an order so that comp prereqs preceed comp
+        If a circular dependancy is passed in fail with recursion error
+        """
         comps_out = []
         for comp in comps_in:
             try:
                 comps_out = self.add_comp(comp, comps_out)
                 #except RecursionError as e:
                 # RecursionError only in py3.5 or later
-            except RuntimeError as e:
-                fatal_error("Circular prereq Dependancy detected")
+            except RuntimeError as error:
+                fatal_error("Circular prereq Dependancy detected {}".format(error))
         return comps_out
 
     def add_comp(self, comp, comps):
+        """
+        Recursive add_comp based on prereq
+        """
         if comp in comps:
             return comps
         prereq = self._all_components[comp].get_prereq()

--- a/manic/sourcetree.py
+++ b/manic/sourcetree.py
@@ -346,7 +346,7 @@ class SourceTree(object):
             tmp_comps = self._required_compnames
 
         load_comps = self.order_comps_by_prereq(tmp_comps)
-        printlog ("load_comps: {}".format(load_comps))
+        printlog("load_comps: {}".format(load_comps))
         # checkout the primary externals
         for comp in load_comps:
             if verbosity < VERBOSITY_VERBOSE:

--- a/manic/sourcetree.py
+++ b/manic/sourcetree.py
@@ -307,8 +307,8 @@ class SourceTree(object):
         for comp in load_comps:
             printlog('{0}, '.format(comp), end='')
             stat = self._all_components[comp].status()
-
-            for name in stat.keys():
+            stat_keys = list(stat.keys())
+            for name in stat_keys:
                 # check if we need to append the relative_path_base to
                 # the path so it will be sorted in the correct order.
                 if not stat[name].path.startswith(relative_path_base):
@@ -343,6 +343,7 @@ class SourceTree(object):
             tmp_comps = [load_comp]
         else:
             tmp_comps = self._required_compnames
+
         load_comps = []
         for comp in tmp_comps:
             prereq = self._all_components[comp].get_prereq()

--- a/manic/sourcetree.py
+++ b/manic/sourcetree.py
@@ -368,6 +368,13 @@ class SourceTree(object):
         If a circular dependancy is passed in fail with recursion error
         """
         comps_out = []
+        # First loop over all comps and check that prereq if provided is valid.
+        for comp in comps_in:
+            prereq = self._all_components[comp].get_prereq()
+            if prereq and prereq not in self._all_components:
+                fatal_error("prereq {} of component {} not found".format(prereq, comp))
+
+        # Now recursively reorder comps to satisfy prereq list
         for comp in comps_in:
             try:
                 comps_out = self.add_comp(comp, comps_out)
@@ -384,11 +391,9 @@ class SourceTree(object):
         if comp in comps:
             return comps
         prereq = self._all_components[comp].get_prereq()
-        if prereq and prereq not in self._all_components:
-            fatal_error("prereq {} of component {} not found".format(prereq, comp))
         if not prereq or prereq in comps and comp not in comps:
             comps.append(comp)
-        elif prereq in self._all_components:
+        else:
             comps = self.add_comp(prereq, comps)
 
         return comps

--- a/manic/sourcetree.py
+++ b/manic/sourcetree.py
@@ -346,7 +346,7 @@ class SourceTree(object):
             tmp_comps = self._required_compnames
 
         load_comps = self.order_comps_by_prereq(tmp_comps)
-        printlog ("load_comps {}".format(load_comps))
+        printlog ("load_comps: {}".format(load_comps))
         # checkout the primary externals
         for comp in load_comps:
             if verbosity < VERBOSITY_VERBOSE:
@@ -388,12 +388,13 @@ class SourceTree(object):
         """
         Recursive add_comp based on prereq
         """
+
         if comp in comps:
             return comps
         prereq = self._all_components[comp].get_prereq()
-        if not prereq or prereq in comps and comp not in comps:
-            comps.append(comp)
-        else:
+        if prereq and prereq not in comps:
             comps = self.add_comp(prereq, comps)
+        if comp not in comps:
+            comps.append(comp)
 
         return comps

--- a/manic/sourcetree.py
+++ b/manic/sourcetree.py
@@ -367,7 +367,9 @@ class SourceTree(object):
         for comp in comps_in:
             try:
                 comps_out = self.add_comp(comp, comps_out)
-            except Exception as e:
+                #except RecursionError as e:
+                # RecursionError only in py3.5 or later
+            except RuntimeError as e:
                 fatal_error("Circular prereq Dependancy detected")
         return comps_out
 

--- a/manic/sourcetree.py
+++ b/manic/sourcetree.py
@@ -91,6 +91,9 @@ class _External(object):
         return self._local_path
 
     def get_prereq(self):
+        """
+        Return the external object's prereq if set
+        """
         return self._prereq
 
     def status(self):
@@ -304,7 +307,7 @@ class SourceTree(object):
         for comp in load_comps:
             printlog('{0}, '.format(comp), end='')
             stat = self._all_components[comp].status()
-            stat_final = {}
+
             for name in stat.keys():
                 # check if we need to append the relative_path_base to
                 # the path so it will be sorted in the correct order.

--- a/manic/utils.py
+++ b/manic/utils.py
@@ -226,6 +226,7 @@ all repositories without entering your authentication information.
            working_directory=working_directory,
            hanging_sec=_HANGING_SEC))
 
+# pylint: disable=R0204
 
 def execute_subprocess(commands, status_to_caller=False,
                        output_to_caller=False):

--- a/test/.pylint.rc
+++ b/test/.pylint.rc
@@ -50,7 +50,7 @@ confidence=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
-disable=bad-continuation,useless-object-inheritance
+disable=bad-continuation,useless-object-inheritance,bad-option-value
 
 
 # Enable the message, report, category or checker with the given id(s). You can

--- a/test/test_sys_checkout.py
+++ b/test/test_sys_checkout.py
@@ -261,7 +261,7 @@ class GenerateExternalsDescriptionCfgV1(object):
     def create_section(self, repo_type, name, tag='', branch='',
                        ref_hash='', required=True, path=EXTERNALS_NAME,
                        externals='', repo_path=None, from_submodule=False,
-                       sparse=''):
+                       sparse='', prereq=None):
         # pylint: disable=too-many-branches
         """Create a config section with autofilling some items and handling
         optional items.
@@ -314,6 +314,9 @@ class GenerateExternalsDescriptionCfgV1(object):
 
         if from_submodule:
             self._config.set(name, ExternalsDescription.SUBMODULE, "True")
+
+        if prereq:
+            self._config.set(name, ExternalsDescription.PREREQ, prereq)
 
     def create_section_ext_only(self, name,
                                 required=True, externals=CFG_SUB_NAME):

--- a/test/test_unit_externals_description.py
+++ b/test/test_unit_externals_description.py
@@ -57,7 +57,7 @@ class TestCfgSchemaVersion(unittest.TestCase):
         """
         self._config = config_parser()
         self._config.add_section('section1')
-        self._config.set('section1', 'keword', 'value')
+        self._config.set('section1', 'keyword', 'value')
 
         self._config.add_section(DESCRIPTION_SECTION)
 
@@ -107,7 +107,7 @@ class TestCfgSchemaVersion(unittest.TestCase):
             get_cfg_schema_version(self._config)
 
 
-class TestModelDescritionConfigV1(unittest.TestCase):
+class TestModelDescriptionConfigV1(unittest.TestCase):
     """Test that parsing config/ini fileproduces a correct dictionary
     for the externals description.
 
@@ -124,6 +124,7 @@ class TestModelDescritionConfigV1(unittest.TestCase):
         self._comp1_tag = 'a_nice_tag_v1'
         self._comp1_is_required = 'True'
         self._comp1_externals = ''
+        self._comp1_prereq = ''
 
         self._comp2_name = 'comp2'
         self._comp2_path = 'path/to/comp2'
@@ -132,6 +133,7 @@ class TestModelDescritionConfigV1(unittest.TestCase):
         self._comp2_branch = 'a_very_nice_branch'
         self._comp2_is_required = 'False'
         self._comp2_externals = 'path/to/comp2.cfg'
+        self._comp2_prereq = ''
 
     def _setup_comp1(self, config):
         """Boiler plate construction of xml string for componet 1
@@ -142,6 +144,8 @@ class TestModelDescritionConfigV1(unittest.TestCase):
         config.set(self._comp1_name, 'repo_url', self._comp1_url)
         config.set(self._comp1_name, 'tag', self._comp1_tag)
         config.set(self._comp1_name, 'required', self._comp1_is_required)
+        if self._comp1_prereq:
+            config.set(self._comp1_name, 'prereq', self._comp1_prereq)
 
     def _setup_comp2(self, config):
         """Boiler plate construction of xml string for componet 2
@@ -153,6 +157,8 @@ class TestModelDescritionConfigV1(unittest.TestCase):
         config.set(self._comp2_name, 'branch', self._comp2_branch)
         config.set(self._comp2_name, 'required', self._comp2_is_required)
         config.set(self._comp2_name, 'externals', self._comp2_externals)
+        if self._comp2_prereq:
+            config.set(self._comp1_name, 'prereq', self._comp2_prereq)
 
     @staticmethod
     def _setup_externals_description(config):
@@ -175,6 +181,8 @@ class TestModelDescritionConfigV1(unittest.TestCase):
         self.assertEqual(repo[ExternalsDescription.REPO_URL], self._comp1_url)
         self.assertEqual(repo[ExternalsDescription.TAG], self._comp1_tag)
         self.assertEqual(EMPTY_STR, comp1[ExternalsDescription.EXTERNALS])
+        self.assertEqual(repo[ExternalsDescription.PREREQ], self._comp1_prereq)
+
 
     def _check_comp2(self, model):
         """Test that component two was constucted correctly.
@@ -190,6 +198,20 @@ class TestModelDescritionConfigV1(unittest.TestCase):
         self.assertEqual(repo[ExternalsDescription.BRANCH], self._comp2_branch)
         self.assertEqual(self._comp2_externals,
                          comp2[ExternalsDescription.EXTERNALS])
+        self.assertEqual(repo[ExternalsDescription.PREREQ], self._comp2_prereq)
+
+    def test_no_prereq_error(self):
+        """
+        Test that an invalid prereq raises an error
+        """
+        config = config_parser()
+        self._setup_comp1(config)
+        config.set(self._comp1_name, 'prereq', 'wilma')
+        self._setup_externals_description(config)
+        model = ExternalsDescriptionConfigV1(config)
+        print(model)
+        self._comp1_prereq = 'wilma'
+        self._check_comp1(model)
 
     def test_one_tag_required(self):
         """Test that a component source with a tag is correctly parsed.


### PR DESCRIPTION
Add a prereq optional field to the Externals file.

Adds an optional prereq field to an external description.  This field if present should be the name of another repository
in the same file.  

User interface changes?: 
[ If yes, describe what changed, and steps taken to ensure backward compatibilty ]

Fixes: #147 

Testing:
  test removed: None
  unit tests: All pass
  system tests: All pass
  manual testing: ufs-s2s-app

