### PR TITLE
Sort by local path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 os: linux
-python: 
-  - "2.7"
+python:
   - "3.4"
   - "3.5"
   - "3.6"

--- a/manic/checkout.py
+++ b/manic/checkout.py
@@ -380,14 +380,14 @@ def main(args):
 
     if args.status:
         # user requested status-only
-        for comp in sorted(tree_status.keys()):
+        for comp in sorted(tree_status):
             tree_status[comp].log_status_message(args.verbose)
     else:
         # checkout / update the external repositories.
         safe_to_update = check_safe_to_update_repos(tree_status)
         if not safe_to_update:
             # print status
-            for comp in sorted(tree_status.keys()):
+            for comp in sorted(tree_status):
                 tree_status[comp].log_status_message(args.verbose)
             # exit gracefully
             msg = """The external repositories labeled with 'M' above are not in a clean state.

--- a/manic/sourcetree.py
+++ b/manic/sourcetree.py
@@ -338,7 +338,7 @@ class SourceTree(object):
             tmp_comps = self._required_compnames
         # Sort by path so that if paths are nested the
         # parent repo is checked out first.
-        load_comps = sorted(tmp_comps,key=lambda comp: self._all_components[comp].get_local_path())
+        load_comps = sorted(tmp_comps, key=lambda comp: self._all_components[comp].get_local_path())
         # checkout the primary externals
         for comp in load_comps:
             if verbosity < VERBOSITY_VERBOSE:

--- a/manic/sourcetree.py
+++ b/manic/sourcetree.py
@@ -336,8 +336,9 @@ class SourceTree(object):
             tmp_comps = [load_comp]
         else:
             tmp_comps = self._required_compnames
-
-        load_comps = self.order_comps_by_local_path(tmp_comps)
+        # Sort by path so that if paths are nested the
+        # parent repo is checked out first.
+        load_comps = sorted(tmp_comps,key=lambda comp: self._all_components[comp].get_local_path())
         # checkout the primary externals
         for comp in load_comps:
             if verbosity < VERBOSITY_VERBOSE:
@@ -347,23 +348,6 @@ class SourceTree(object):
                 # output a newline
                 printlog(EMPTY_STR)
             self._all_components[comp].checkout(verbosity, load_all)
-        printlog('')
-
-        # now give each external an opportunitity to checkout it's externals.
-        for comp in load_comps:
+            # now give each external an opportunitity to checkout it's externals.
             self._all_components[comp].checkout_externals(verbosity, load_all)
-
-    def order_comps_by_local_path(self, comps_in):
-        """
-        put the comps into an order so that comp local_paths
-        that are nested are checked out in correct order
-        """
-        comps_out = []
-        local_paths = []
-        for comp in comps_in:
-            local_paths.append(self._all_components[comp].get_local_path())
-        for path in sorted(local_paths, key=len):
-            for comp in comps_in:
-                if self._all_components[comp].get_local_path() == path:
-                    comps_out.append(comp)
-        return comps_out
+        printlog('')

--- a/manic/sourcetree.py
+++ b/manic/sourcetree.py
@@ -337,7 +337,7 @@ class SourceTree(object):
         else:
             tmp_comps = self._required_compnames
 
-        load_comps = self.order_comps_by_local_path(self, tmp_comps)
+        load_comps = self.order_comps_by_local_path(tmp_comps)
 
         # checkout the primary externals
         for comp in load_comps:

--- a/manic/sourcetree.py
+++ b/manic/sourcetree.py
@@ -338,7 +338,6 @@ class SourceTree(object):
             tmp_comps = self._required_compnames
 
         load_comps = self.order_comps_by_local_path(tmp_comps)
-
         # checkout the primary externals
         for comp in load_comps:
             if verbosity < VERBOSITY_VERBOSE:
@@ -363,10 +362,8 @@ class SourceTree(object):
         local_paths = []
         for comp in comps_in:
             local_paths.append(self._all_components[comp].get_local_path())
-        local_paths = list(set(local_paths))
         for path in sorted(local_paths, key=len):
             for comp in comps_in:
                 if self._all_components[comp].get_local_path() == path:
                     comps_out.append(comp)
-        comps_out = list(set(comps_out))
         return comps_out

--- a/manic/utils.py
+++ b/manic/utils.py
@@ -255,7 +255,7 @@ def execute_subprocess(commands, status_to_caller=False,
     hanging_timer.start()
     try:
         output = subprocess.check_output(commands, stderr=subprocess.STDOUT,
-                                         universal_newlines=True).decode('utf-8')
+                                         universal_newlines=True)
         log_process_output(output)
         status = 0
     except OSError as error:

--- a/manic/utils.py
+++ b/manic/utils.py
@@ -255,7 +255,7 @@ def execute_subprocess(commands, status_to_caller=False,
     hanging_timer.start()
     try:
         output = subprocess.check_output(commands, stderr=subprocess.STDOUT,
-                                         universal_newlines=True)
+                                         universal_newlines=True).decode('utf-8')
         log_process_output(output)
         status = 0
     except OSError as error:

--- a/test/test_sys_checkout.py
+++ b/test/test_sys_checkout.py
@@ -1681,7 +1681,6 @@ class TestSubrepoCheckout(BaseTestSysCheckout):
         """
 
         # Run the basic setup
-        #super(TestSubrepoCheckout, self).setUp()
         super().setUp()
         # create test repo
         # We need to do this here (rather than have a static repo) because

--- a/test/test_sys_checkout.py
+++ b/test/test_sys_checkout.py
@@ -162,7 +162,7 @@ class GenerateExternalsDescriptionCfgV1(object):
 
         self.write_config(dest_dir)
 
-    def container_nested_required(self, dest_dir, order=[0,1,2]):
+    def container_nested_required(self, dest_dir, order):
         """Create a container externals file with only simple externals.
 
         """
@@ -174,7 +174,7 @@ class GenerateExternalsDescriptionCfgV1(object):
                             branch=REMOTE_BRANCH_FEATURE2, path=NESTED_NAME[order[1]])
 
         self.create_section(SIMPLE_REPO_NAME, 'simp_hash', nested=True,
-                            ref_hash='60b1cc1a38d63',path=NESTED_NAME[order[2]])
+                            ref_hash='60b1cc1a38d63', path=NESTED_NAME[order[2]])
 
         self.write_config(dest_dir)
 
@@ -794,7 +794,7 @@ class BaseTestSysCheckout(unittest.TestCase):
         self._check_simple_branch_empty(tree)
         self._check_simple_hash_empty(tree)
 
-    def _check_container_nested_required_pre_checkout(self, overall, tree, order=[0,1,2]):
+    def _check_container_nested_required_pre_checkout(self, overall, tree, order):
         self.assertEqual(overall, 0)
         self._check_nested_tag_empty(tree, name=NESTED_NAME[order[0]])
         self._check_nested_branch_empty(tree, name=NESTED_NAME[order[1]])
@@ -807,7 +807,7 @@ class BaseTestSysCheckout(unittest.TestCase):
         self._check_simple_branch_empty(tree)
         self._check_simple_hash_empty(tree)
 
-    def _check_container_nested_required_checkout(self, overall, tree, order=[0,1,2]):
+    def _check_container_nested_required_checkout(self, overall, tree, order):
         # Note, this is the internal tree status just before checkout
         self.assertEqual(overall, 0)
         self._check_nested_tag_empty(tree, name=NESTED_NAME[order[0]])
@@ -820,7 +820,7 @@ class BaseTestSysCheckout(unittest.TestCase):
         self._check_simple_branch_ok(tree)
         self._check_simple_hash_ok(tree)
 
-    def _check_container_nested_required_post_checkout(self, overall, tree, order=[0,1,2]):
+    def _check_container_nested_required_post_checkout(self, overall, tree, order):
         self.assertEqual(overall, 0)
         self._check_nested_tag_ok(tree, name=NESTED_NAME[order[0]])
         self._check_nested_branch_ok(tree, name=NESTED_NAME[order[1]])
@@ -1029,29 +1029,30 @@ class TestSysCheckout(BaseTestSysCheckout):
         Tests over all possible permutations
         """
 
-        orders = [[0,1,2], [1,2,0], [2,0,1], [0,2,1], [2,1,0], [1,0,2]]
+        orders = [[0, 1, 2], [1, 2, 0], [2, 0, 1],
+                  [0, 2, 1], [2, 1, 0], [1, 0, 2]]
         for n, order in enumerate(orders):
             # create repo
-            dest_dir=os.path.join(os.environ[MANIC_TEST_TMP_REPO_ROOT],
-                                  self._test_id,"test"+str(n))
+            dest_dir = os.path.join(os.environ[MANIC_TEST_TMP_REPO_ROOT],
+                                  self._test_id, "test"+str(n))
             under_test_dir = self.setup_test_repo(CONTAINER_REPO_NAME,
                                                   dest_dir_in=dest_dir)
-            self._generator.container_nested_required(under_test_dir, order=order)
+            self._generator.container_nested_required(under_test_dir, order)
 
             # status of empty repo
             overall, tree = self.execute_cmd_in_dir(under_test_dir,
                                                     self.status_args)
-            self._check_container_nested_required_pre_checkout(overall, tree, order=order)
+            self._check_container_nested_required_pre_checkout(overall, tree, order)
 
             # checkout
             overall, tree = self.execute_cmd_in_dir(under_test_dir,
                                                     self.checkout_args)
-            self._check_container_nested_required_checkout(overall, tree, order=order)
+            self._check_container_nested_required_checkout(overall, tree, order)
 
             # status clean checked out
             overall, tree = self.execute_cmd_in_dir(under_test_dir,
                                                     self.status_args)
-            self._check_container_nested_required_post_checkout(overall, tree, order=order)
+            self._check_container_nested_required_post_checkout(overall, tree, order)
 
     def test_container_simple_optional(self):
         """Verify that container with an optional simple subrepos

--- a/test/test_sys_checkout.py
+++ b/test/test_sys_checkout.py
@@ -1591,7 +1591,8 @@ class TestSubrepoCheckout(BaseTestSysCheckout):
         """
 
         # Run the basic setup
-        super(TestSubrepoCheckout, self).setUp()
+        #super(TestSubrepoCheckout, self).setUp()
+        super().setUp()
         # create test repo
         # We need to do this here (rather than have a static repo) because
         # git submodules do not allow for variables in .gitmodules files


### PR DESCRIPTION
Sort comps to be checked out by local_path, checking out comp with shortest local
path first, this solves issue #147 without the need for a new field in the Externals.cfg file.

User interface changes?: No

Fixes: #147  and superceeds #151 

Testing:
  test removed: None
  unit tests: all pass
  system tests: all pass 
  manual testing: ufs-s2s-app

