### PR TITLE
When on a branch, show tag/hash, too

### DIFF
--- a/manic/externals_description.py
+++ b/manic/externals_description.py
@@ -193,6 +193,9 @@ def parse_submodules_desc_section(section_items, file_path):
 def read_gitmodules_file(root_dir, file_name):
     # pylint: disable=deprecated-method
     # Disabling this check because the method is only used for python2
+    # pylint: disable=too-many-locals
+    # pylint: disable=too-many-branches
+    # pylint: disable=too-many-statements
     """Read a .gitmodules file and convert it to be compatible with an
     externals description.
     """

--- a/manic/repository_git.py
+++ b/manic/repository_git.py
@@ -135,7 +135,7 @@ class GitRepository(Repository):
             # If we're on a branch, include branch name in current ref
             branch_found, branch_name = self._git_current_branch()
             if branch_found:
-                current_ref = "{} ({})".format(branch_name, current_ref)
+                current_ref = "{} (branch {})".format(current_ref, branch_name)
         else:
             # If we still can't find a ref, return empty string. This
             # can happen if we're not actually in a git repo

--- a/manic/repository_git.py
+++ b/manic/repository_git.py
@@ -109,26 +109,20 @@ class GitRepository(Repository):
     def _current_ref(self):
         """Determine the *name* associated with HEAD.
 
-        If we're on a branch, then returns the branch name; otherwise,
-        if we're on a tag, then returns the tag name; otherwise, returns
+        If we're on a tag, then returns the tag name; otherwise, returns
         the current hash. Returns an empty string if no reference can be
         determined (e.g., if we're not actually in a git repository).
+
+        If we're on a branch, then the branch name is also included in
+        the returned string (in addition to the tag / hash).
         """
         ref_found = False
 
-        # If we're on a branch, then use that as the current ref
-        branch_found, branch_name = self._git_current_branch()
-        if branch_found:
-            current_ref = branch_name
+        # If we're exactly at a tag, use that as the current ref
+        tag_found, tag_name = self._git_current_tag()
+        if tag_found:
+            current_ref = tag_name
             ref_found = True
-
-        if not ref_found:
-            # Otherwise, if we're exactly at a tag, use that as the
-            # current ref
-            tag_found, tag_name = self._git_current_tag()
-            if tag_found:
-                current_ref = tag_name
-                ref_found = True
 
         if not ref_found:
             # Otherwise, use current hash as the current ref
@@ -137,7 +131,12 @@ class GitRepository(Repository):
                 current_ref = hash_name
                 ref_found = True
 
-        if not ref_found:
+        if ref_found:
+            # If we're on a branch, include branch name in current ref
+            branch_found, branch_name = self._git_current_branch()
+            if branch_found:
+                current_ref = "{} ({})".format(branch_name, current_ref)
+        else:
             # If we still can't find a ref, return empty string. This
             # can happen if we're not actually in a git repo
             current_ref = ''

--- a/test/test_sys_checkout.py
+++ b/test/test_sys_checkout.py
@@ -38,7 +38,6 @@ import logging
 import os
 import os.path
 import shutil
-import sys
 import unittest
 
 from manic.externals_description import ExternalsDescription

--- a/test/test_unit_repository_git.py
+++ b/test/test_unit_repository_git.py
@@ -101,7 +101,7 @@ class TestGitRepositoryCurrentRef(unittest.TestCase):
             True, 'feature3')
         self._repo._git_current_tag = self._git_current_tag(True, 'foo_tag')
         self._repo._git_current_hash = self._git_current_hash(True, 'abc123')
-        expected = 'feature3 (foo_tag)'
+        expected = 'foo_tag (branch feature3)'
         result = self._repo._current_ref()
         self.assertEqual(result, expected)
 

--- a/test/test_unit_repository_git.py
+++ b/test/test_unit_repository_git.py
@@ -101,7 +101,7 @@ class TestGitRepositoryCurrentRef(unittest.TestCase):
             True, 'feature3')
         self._repo._git_current_tag = self._git_current_tag(True, 'foo_tag')
         self._repo._git_current_hash = self._git_current_hash(True, 'abc123')
-        expected = 'feature3'
+        expected = 'feature3 (foo_tag)'
         result = self._repo._current_ref()
         self.assertEqual(result, expected)
 


### PR DESCRIPTION
When on a branch, show tag/hash, too

For the sake of recording provenance, it is not sufficient to know the branch you're on: you also need to know the hash or tag. So show both when printing the current reference.

Example output of excerpts from `checkout_externals -S -v`:

In sync:

```
    ./cime/src/drivers/nuopc/
        clean sandbox, on 3810a7a000e993267e1774c9a985891db3f9d137 (branch mvertens/fixglc_runseq)
```

Out of sync:

```
s   ./cime/src/drivers/nuopc/
        clean sandbox, 3810a7a000e993267e1774c9a985891db3f9d137 (branch mvertens/fixglc_runseq) --> 147e8a6
```

Previously in these cases, the current hash (`3810a7a...`) wasn't shown: only the branch name was shown.

User interface changes?: Yes: Just changes output a bit

Fixes: none

Testing:
  test removed: none
  unit tests: pass
  system tests: pass
  manual testing: manually checked output in a few cases (e.g., see above)

