### PR TITLE
remove python2, do not lower case

### DIFF
--- a/checkout_externals
+++ b/checkout_externals
@@ -6,20 +6,17 @@ Tool to assemble external respositories represented in an externals
 description file.
 
 """
-from __future__ import absolute_import
-from __future__ import unicode_literals
-from __future__ import print_function
 
 import sys
 import traceback
 
 import manic
 
-if sys.hexversion < 0x02070000:
+if sys.hexversion < 0x03060000:
     print(70 * '*')
-    print(f'ERROR: {0} requires python >= 2.7.x. '.format(sys.argv[0]))
-    print(f'It appears that you are running python {0}'.format(
-        '.'.join(str(x) for x in sys.version_info[0:3])))
+    print(f'ERROR: {sys.argv[0]} requires python >= 3.6.x. ')
+    version = '.'.join(str(x) for x in sys.version_info[0:3])
+    print(f'It appears that you are running python {version}')
     print(70 * '*')
     sys.exit(1)
 

--- a/checkout_externals
+++ b/checkout_externals
@@ -17,8 +17,8 @@ import manic
 
 if sys.hexversion < 0x02070000:
     print(70 * '*')
-    print('ERROR: {0} requires python >= 2.7.x. '.format(sys.argv[0]))
-    print('It appears that you are running python {0}'.format(
+    print(f'ERROR: {0} requires python >= 2.7.x. '.format(sys.argv[0]))
+    print(f'It appears that you are running python {0}'.format(
         '.'.join(str(x) for x in sys.version_info[0:3])))
     print(70 * '*')
     sys.exit(1)

--- a/manic/__init__.py
+++ b/manic/__init__.py
@@ -5,5 +5,6 @@ from manic import checkout
 from manic.utils import printlog
 
 __all__ = [
-    'checkout', 'printlog',
+    "checkout",
+    "printlog",
 ]

--- a/manic/checkout.py
+++ b/manic/checkout.py
@@ -24,11 +24,14 @@ from manic.utils import printlog, fatal_error
 from manic.global_constants import VERSION_SEPERATOR, LOG_FILE_NAME
 
 if sys.hexversion < 0x02070000:
-    print(70 * '*')
-    print('ERROR: {0} requires python >= 2.7.x. '.format(sys.argv[0]))
-    print('It appears that you are running python {0}'.format(
-        VERSION_SEPERATOR.join(str(x) for x in sys.version_info[0:3])))
-    print(70 * '*')
+    print(70 * "*")
+    print(f"ERROR: {0} requires python >= 2.7.x. ".format(sys.argv[0]))
+    print(
+        f"It appears that you are running python {0}".format(
+            VERSION_SEPERATOR.join(str(x) for x in sys.version_info[0:3])
+        )
+    )
+    print(70 * "*")
     sys.exit(1)
 
 
@@ -45,7 +48,7 @@ def commandline_arguments(args=None):
 
     Returns: processed command line arguments
     """
-    description = '''
+    description = """
 
 %(prog)s manages checking out groups of externals from revision
 control based on an externals description file. By default only the
@@ -53,9 +56,9 @@ required externals are checkout out.
 
 Running %(prog)s without the '--status' option will always attempt to
 synchronize the working copy to exactly match the externals description.
-'''
+"""
 
-    epilog = '''
+    epilog = """
 ```
 NOTE: %(prog)s *MUST* be run from the root of the source tree it
 is managing. For example, if you cloned a repository with:
@@ -261,70 +264,114 @@ If %(prog)s is not doing what you expected, double check the contents
 of the externals description file or examine the output of
 ./manage_externals/%(prog)s --status
 
-'''
+"""
 
     parser = argparse.ArgumentParser(
-        description=description, epilog=epilog,
-        formatter_class=argparse.RawDescriptionHelpFormatter)
+        description=description,
+        epilog=epilog,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
 
     #
     # user options
     #
-    parser.add_argument("components", nargs="*",
-                        help="Specific component(s) to checkout. By default, "
-                        "all required externals are checked out.")
+    parser.add_argument(
+        "components",
+        nargs="*",
+        help="Specific component(s) to checkout. By default, "
+        "all required externals are checked out.",
+    )
 
-    parser.add_argument('-e', '--externals', nargs='?',
-                        default='Externals.cfg',
-                        help='The externals description filename. '
-                        'Default: %(default)s.')
+    parser.add_argument(
+        "-e",
+        "--externals",
+        nargs="?",
+        default="Externals.cfg",
+        help="The externals description filename. " "Default: %(default)s.",
+    )
 
-    parser.add_argument('-x', '--exclude', nargs='*',
-                        help='Component(s) listed in the externals file which should be ignored.')
+    parser.add_argument(
+        "-x",
+        "--exclude",
+        nargs="*",
+        help="Component(s) listed in the externals file which should be ignored.",
+    )
 
-    parser.add_argument('-o', '--optional', action='store_true', default=False,
-                        help='By default only the required externals '
-                        'are checked out. This flag will also checkout the '
-                        'optional externals.')
+    parser.add_argument(
+        "-o",
+        "--optional",
+        action="store_true",
+        default=False,
+        help="By default only the required externals "
+        "are checked out. This flag will also checkout the "
+        "optional externals.",
+    )
 
-    parser.add_argument('-S', '--status', action='store_true', default=False,
-                        help='Output the status of the repositories managed by '
-                        '%(prog)s. By default only summary information '
-                        'is provided. Use the verbose option to see details.')
+    parser.add_argument(
+        "-S",
+        "--status",
+        action="store_true",
+        default=False,
+        help="Output the status of the repositories managed by "
+        "%(prog)s. By default only summary information "
+        "is provided. Use the verbose option to see details.",
+    )
 
-    parser.add_argument('-v', '--verbose', action='count', default=0,
-                        help='Output additional information to '
-                        'the screen and log file. This flag can be '
-                        'used up to two times, increasing the '
-                        'verbosity level each time.')
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="count",
+        default=0,
+        help="Output additional information to "
+        "the screen and log file. This flag can be "
+        "used up to two times, increasing the "
+        "verbosity level each time.",
+    )
 
-    parser.add_argument('--svn-ignore-ancestry', action='store_true', default=False,
-                        help='By default, subversion will abort if a component is '
-                        'already checked out and there is no common ancestry with '
-                        'the new URL. This flag passes the "--ignore-ancestry" flag '
-                        'to the svn switch call. (This is not recommended unless '
-                        'you are sure about what you are doing.)')
+    parser.add_argument(
+        "--svn-ignore-ancestry",
+        action="store_true",
+        default=False,
+        help="By default, subversion will abort if a component is "
+        "already checked out and there is no common ancestry with "
+        'the new URL. This flag passes the "--ignore-ancestry" flag '
+        "to the svn switch call. (This is not recommended unless "
+        "you are sure about what you are doing.)",
+    )
 
     #
     # developer options
     #
-    parser.add_argument('--backtrace', action='store_true',
-                        help='DEVELOPER: show exception backtraces as extra '
-                        'debugging output')
+    parser.add_argument(
+        "--backtrace",
+        action="store_true",
+        help="DEVELOPER: show exception backtraces as extra " "debugging output",
+    )
 
-    parser.add_argument('-d', '--debug', action='store_true', default=False,
-                        help='DEVELOPER: output additional debugging '
-                        'information to the screen and log file.')
+    parser.add_argument(
+        "-d",
+        "--debug",
+        action="store_true",
+        default=False,
+        help="DEVELOPER: output additional debugging "
+        "information to the screen and log file.",
+    )
 
     logging_group = parser.add_mutually_exclusive_group()
 
-    logging_group.add_argument('--logging', dest='do_logging',
-                               action='store_true',
-                               help='DEVELOPER: enable logging.')
-    logging_group.add_argument('--no-logging', dest='do_logging',
-                               action='store_false', default=False,
-                               help='DEVELOPER: disable logging '
-                               '(this is the default)')
+    logging_group.add_argument(
+        "--logging",
+        dest="do_logging",
+        action="store_true",
+        help="DEVELOPER: enable logging.",
+    )
+    logging_group.add_argument(
+        "--no-logging",
+        dest="do_logging",
+        action="store_false",
+        default=False,
+        help="DEVELOPER: disable logging " "(this is the default)",
+    )
 
     if args:
         options = parser.parse_args(args)
@@ -350,13 +397,15 @@ def main(args):
     used to determine if it's safe to proceed with the checkout.
     """
     if args.do_logging:
-        logging.basicConfig(filename=LOG_FILE_NAME,
-                            format='%(levelname)s : %(asctime)s : %(message)s',
-                            datefmt='%Y-%m-%d %H:%M:%S',
-                            level=logging.DEBUG)
+        logging.basicConfig(
+            filename=LOG_FILE_NAME,
+            format="%(levelname)s : %(asctime)s : %(message)s",
+            datefmt="%Y-%m-%d %H:%M:%S",
+            level=logging.DEBUG,
+        )
 
     program_name = os.path.basename(sys.argv[0])
-    logging.info('Beginning of %s', program_name)
+    logging.info("Beginning of %s", program_name)
 
     load_all = False
     if args.optional:
@@ -365,18 +414,19 @@ def main(args):
     root_dir = os.path.abspath(os.getcwd())
     external_data = read_externals_description_file(root_dir, args.externals)
     external = create_externals_description(
-        external_data, components=args.components, exclude=args.exclude)
+        external_data, components=args.components, exclude=args.exclude
+    )
 
     for comp in args.components:
         if comp not in external.keys():
-            fatal_error(
-                "No component {} found in {}".format(
-                    comp, args.externals))
+            fatal_error(f"No component {comp} found in {args.externals}")
 
-    source_tree = SourceTree(root_dir, external, svn_ignore_ancestry=args.svn_ignore_ancestry)
-    printlog('Checking status of externals: ', end='')
+    source_tree = SourceTree(
+        root_dir, external, svn_ignore_ancestry=args.svn_ignore_ancestry
+    )
+    printlog("Checking status of externals: ", end="")
     tree_status = source_tree.status()
-    printlog('')
+    printlog("")
 
     if args.status:
         # user requested status-only
@@ -423,18 +473,20 @@ control using the expected protocol. If you are sure you want to switch
 protocols, and you don't have any work you need to save from this
 directory, then run "rm -rf [directory]" before rerunning the
 {program_name} tool.
-""".format(program_name=program_name, config_file=args.externals)
+""".format(
+                program_name=program_name, config_file=args.externals
+            )
 
-            printlog('-' * 70)
+            printlog("-" * 70)
             printlog(msg)
-            printlog('-' * 70)
+            printlog("-" * 70)
         else:
             if not args.components:
                 source_tree.checkout(args.verbose, load_all)
             for comp in args.components:
                 source_tree.checkout(args.verbose, load_all, load_comp=comp)
-            printlog('')
+            printlog("")
 
-    logging.info('%s completed without exceptions.', program_name)
+    logging.info("%s completed without exceptions.", program_name)
     # NOTE(bja, 2017-11) tree status is used by the systems tests
     return 0, tree_status

--- a/manic/externals_description.py
+++ b/manic/externals_description.py
@@ -44,7 +44,7 @@ def read_externals_description_file(root_dir, file_name):
     root_dir = os.path.abspath(root_dir)
     msg = f"In directory : {root_dir}"
     logging.info(msg)
-    printlog("Processing externals description file : {file_name}")
+    printlog(f"Processing externals description file : {file_name}")
 
     file_path = os.path.join(root_dir, file_name)
     if not os.path.exists(file_name):

--- a/manic/externals_description.py
+++ b/manic/externals_description.py
@@ -32,8 +32,8 @@ from .global_constants import EMPTY_STR, PPRINTER, VERSION_SEPERATOR
 #
 # Globals
 #
-DESCRIPTION_SECTION = 'externals_description'
-VERSION_ITEM = 'schema_version'
+DESCRIPTION_SECTION = "externals_description"
+VERSION_ITEM = "schema_version"
 
 
 def read_externals_description_file(root_dir, file_name):
@@ -42,19 +42,23 @@ def read_externals_description_file(root_dir, file_name):
 
     """
     root_dir = os.path.abspath(root_dir)
-    msg = 'In directory : {0}'.format(root_dir)
+    msg = f"In directory : {root_dir}"
     logging.info(msg)
-    printlog('Processing externals description file : {0}'.format(file_name))
+    printlog("Processing externals description file : {file_name}")
 
     file_path = os.path.join(root_dir, file_name)
     if not os.path.exists(file_name):
         if file_name.lower() == "none":
-            msg = ('INTERNAL ERROR: Attempt to read externals file '
-                   'from {0} when not configured'.format(file_path))
+            msg = (
+                "INTERNAL ERROR: Attempt to read externals file "
+                f"from {file_path} when not configured"
+            )
         else:
-            msg = ('ERROR: Model description file, "{0}", does not '
-                   'exist at path:\n    {1}\nDid you run from the root of '
-                   'the source tree?'.format(file_name, file_path))
+            msg = (
+                f'ERROR: Model description file, "{file_name}", does not '
+                f"exist at path:\n    {file_path}\nDid you run from the root of "
+                "the source tree?"
+            )
 
         fatal_error(msg)
 
@@ -71,17 +75,19 @@ def read_externals_description_file(root_dir, file_name):
             pass
 
     if externals_description is None:
-        msg = 'Unknown file format!'
+        msg = "Unknown file format!"
         fatal_error(msg)
 
     return externals_description
 
+
 class LstripReader(object):
     "LstripReader formats .gitmodules files to be acceptable for configparser"
+
     def __init__(self, filename):
-        with open(filename, 'r') as infile:
+        with open(filename, "r", encoding="utf-8") as infile:
             lines = infile.readlines()
-        self._lines = list()
+        self._lines = []
         self._num_lines = len(lines)
         self._index = 0
         for line in lines:
@@ -96,7 +102,7 @@ class LstripReader(object):
         try:
             line = self.next()
         except StopIteration:
-            line = ''
+            line = ""
 
         if (size > 0) and (len(line) < size):
             return line[0:size]
@@ -119,29 +125,30 @@ class LstripReader(object):
     def __next__(self):
         return self.next()
 
+
 def git_submodule_status(repo_dir):
-    """Run the git submodule status command to obtain submodule hashes.
-        """
+    """Run the git submodule status command to obtain submodule hashes."""
     # This function is here instead of GitRepository to avoid a dependency loop
     cwd = os.getcwd()
     os.chdir(repo_dir)
-    cmd = ['git', 'submodule', 'status']
+    cmd = ["git", "submodule", "status"]
     git_output = execute_subprocess(cmd, output_to_caller=True)
     submodules = {}
-    submods = git_output.split('\n')
+    submods = git_output.split("\n")
     for submod in submods:
         if submod:
             status = submod[0]
-            items = submod[1:].split(' ')
+            items = submod[1:].split(" ")
             if len(items) > 2:
                 tag = items[2]
             else:
                 tag = None
 
-            submodules[items[1]] = {'hash':items[0], 'status':status, 'tag':tag}
+            submodules[items[1]] = {"hash": items[0], "status": status, "tag": tag}
 
     os.chdir(cwd)
     return submodules
+
 
 def parse_submodules_desc_section(section_items, file_path):
     """Find the path and url for this submodule description"""
@@ -149,33 +156,37 @@ def parse_submodules_desc_section(section_items, file_path):
     url = None
     for item in section_items:
         name = item[0].strip()
-        if name == 'path':
+        if name == "path":
             path = item[1].strip()
-        elif name == 'url':
+        elif name == "url":
             url = item[1].strip()
-        elif name == 'branch':
+        elif name == "branch":
             # We do not care about branch since we have a hash - silently ignore
             pass
         else:
-            msg = 'WARNING: Ignoring unknown {} property, in {}'
-            msg = msg.format(item[0], file_path) # fool pylint
+            msg = "WARNING: Ignoring unknown {} property, in {}"
+            msg = msg.format(item[0], file_path)  # fool pylint
             logging.warning(msg)
 
     return path, url
+
 
 def read_gitmodules_file(root_dir, file_name):
     """Read a .gitmodules file and convert it to be compatible with an
     externals description.
     """
+    # pylint: disable=too-many-locals
     root_dir = os.path.abspath(root_dir)
-    msg = 'In directory : {0}'.format(root_dir)
+    msg = f"In directory : {root_dir}"
     logging.info(msg)
-    printlog('Processing submodules description file : {0}'.format(file_name))
+    printlog(f"Processing submodules description file : {file_name}")
 
     file_path = os.path.join(root_dir, file_name)
     if not os.path.exists(file_name):
-        msg = ('ERROR: submodules description file, "{0}", does not '
-               'exist at path:\n    {1}'.format(file_name, file_path))
+        msg = (
+            f'ERROR: submodules description file, "{file_name}", does not '
+            f"exist at path:\n    {file_path}"
+        )
         fatal_error(msg)
 
     submodules_description = None
@@ -190,7 +201,7 @@ def read_gitmodules_file(root_dir, file_name):
         pass
 
     if submodules_description is None:
-        msg = 'Unknown file format!'
+        msg = "Unknown file format!"
         fatal_error(msg)
     else:
         # Convert the submodules description to an externals description
@@ -198,29 +209,28 @@ def read_gitmodules_file(root_dir, file_name):
         # We need to grab all the commit hashes for this repo
         submods = git_submodule_status(root_dir)
         for section in submodules_description.sections():
-            if section[0:9] == 'submodule':
+            if section[0:9] == "submodule":
                 sec_name = section[9:].strip(' "')
                 externals_description.add_section(sec_name)
                 section_items = submodules_description.items(section)
-                path, url = parse_submodules_desc_section(section_items,
-                                                          file_path)
+                path, url = parse_submodules_desc_section(section_items, file_path)
 
                 if path is None:
-                    msg = 'Submodule {} missing path'.format(sec_name)
+                    msg = f"Submodule {sec_name} missing path"
                     fatal_error(msg)
 
                 if url is None:
-                    msg = 'Submodule {} missing url'.format(sec_name)
+                    msg = f"Submodule {sec_name} missing url"
                     fatal_error(msg)
 
-                externals_description.set(sec_name,
-                                          ExternalsDescription.PATH, path)
-                externals_description.set(sec_name,
-                                          ExternalsDescription.PROTOCOL, 'git')
-                externals_description.set(sec_name,
-                                          ExternalsDescription.REPO_URL, url)
-                externals_description.set(sec_name,
-                                          ExternalsDescription.REQUIRED, 'True')
+                externals_description.set(sec_name, ExternalsDescription.PATH, path)
+                externals_description.set(
+                    sec_name, ExternalsDescription.PROTOCOL, "git"
+                )
+                externals_description.set(sec_name, ExternalsDescription.REPO_URL, url)
+                externals_description.set(
+                    sec_name, ExternalsDescription.REQUIRED, "True"
+                )
                 if sec_name in submods:
                     submod_name = sec_name
                 else:
@@ -228,40 +238,50 @@ def read_gitmodules_file(root_dir, file_name):
                     submod_name = path
 
                 if submod_name in submods:
-                    git_hash = submods[submod_name]['hash']
-                    externals_description.set(sec_name,
-                                              ExternalsDescription.HASH,
-                                              git_hash)
+                    git_hash = submods[submod_name]["hash"]
+                    externals_description.set(
+                        sec_name, ExternalsDescription.HASH, git_hash
+                    )
                 else:
-                    emsg = "submodule status has no section, '{}'"
-                    emsg += "\nCheck section names in externals config file"
-                    fatal_error(emsg.format(submod_name))
+                    emsg = (
+                        f"submodule status has no section, '{submod_name}'"
+                        "\nCheck section names in externals config file"
+                    )
+                    fatal_error(emsg)
 
         # Required items
         externals_description.add_section(DESCRIPTION_SECTION)
-        externals_description.set(DESCRIPTION_SECTION, VERSION_ITEM, '1.0.0')
+        externals_description.set(DESCRIPTION_SECTION, VERSION_ITEM, "1.0.0")
 
     return externals_description
 
+
 def create_externals_description(
-        model_data, model_format='cfg', components=None, exclude=None, parent_repo=None):
-    """Create the a externals description object from the provided data
-    """
+    model_data, model_format="cfg", components=None, exclude=None, parent_repo=None
+):
+    """Create the a externals description object from the provided data"""
     externals_description = None
-    if model_format == 'dict':
+    if model_format == "dict":
         externals_description = ExternalsDescriptionDict(
-            model_data, components=components, exclude=exclude)
-    elif model_format == 'cfg':
+            model_data, components=components, exclude=exclude
+        )
+    elif model_format == "cfg":
         major, _, _ = get_cfg_schema_version(model_data)
         if major == 1:
             externals_description = ExternalsDescriptionConfigV1(
-                model_data, components=components, exclude=exclude, parent_repo=parent_repo)
+                model_data,
+                components=components,
+                exclude=exclude,
+                parent_repo=parent_repo,
+            )
         else:
-            msg = ('Externals description file has unsupported schema '
-                   'version "{0}".'.format(major))
+            msg = (
+                "Externals description file has unsupported schema "
+                f'version "{major}".'
+            )
             fatal_error(msg)
     else:
-        msg = 'Unknown model data format "{0}"'.format(model_format)
+        msg = f'Unknown model data format "{model_format}"'
         fatal_error(msg)
     return externals_description
 
@@ -277,18 +297,19 @@ def get_cfg_schema_version(model_cfg):
     minor = integer minor version
     patch = integer patch version
     """
-    semver_str = ''
+    semver_str = ""
     try:
         semver_str = model_cfg.get(DESCRIPTION_SECTION, VERSION_ITEM)
     except (NoSectionError, NoOptionError):
-        msg = ('externals description file must have the required '
-               'section: "{0}" and item "{1}"'.format(DESCRIPTION_SECTION,
-                                                      VERSION_ITEM))
+        msg = (
+            "externals description file must have the required "
+            f'section: "{DESCRIPTION_SECTION}" and item "{VERSION_ITEM}"'
+        )
         fatal_error(msg)
 
     # NOTE(bja, 2017-11) Assume we don't care about the
     # build/pre-release metadata for now!
-    version_list = re.split(r'[-+]', semver_str)
+    version_list = re.split(r"[-+]", semver_str)
     version_str = version_list[0]
     version = version_str.split(VERSION_SEPERATOR)
     try:
@@ -296,9 +317,11 @@ def get_cfg_schema_version(model_cfg):
         minor = int(version[1].strip())
         patch = int(version[2].strip())
     except ValueError:
-        msg = ('Config file schema version must have integer digits for '
-               'major, minor and patch versions. '
-               'Received "{0}"'.format(version_str))
+        msg = (
+            "Config file schema version must have integer digits for "
+            "major, minor and patch versions. "
+            f'Received "{version_str}"'
+        )
         fatal_error(msg)
     return major, minor, patch
 
@@ -322,45 +345,48 @@ class ExternalsDescription(dict):
     input value.
 
     """
-    # keywords defining the interface into the externals description data
-    EXTERNALS = 'externals'
-    BRANCH = 'branch'
-    SUBMODULE = 'from_submodule'
-    HASH = 'hash'
-    NAME = 'name'
-    PATH = 'local_path'
-    PROTOCOL = 'protocol'
-    REPO = 'repo'
-    REPO_URL = 'repo_url'
-    REQUIRED = 'required'
-    TAG = 'tag'
-    SPARSE = 'sparse'
 
-    PROTOCOL_EXTERNALS_ONLY = 'externals_only'
-    PROTOCOL_GIT = 'git'
-    PROTOCOL_SVN = 'svn'
-    GIT_SUBMODULES_FILENAME = '.gitmodules'
+    # keywords defining the interface into the externals description data
+    EXTERNALS = "externals"
+    BRANCH = "branch"
+    SUBMODULE = "from_submodule"
+    HASH = "hash"
+    NAME = "name"
+    PATH = "local_path"
+    PROTOCOL = "protocol"
+    REPO = "repo"
+    REPO_URL = "repo_url"
+    REQUIRED = "required"
+    TAG = "tag"
+    SPARSE = "sparse"
+
+    PROTOCOL_EXTERNALS_ONLY = "externals_only"
+    PROTOCOL_GIT = "git"
+    PROTOCOL_SVN = "svn"
+    GIT_SUBMODULES_FILENAME = ".gitmodules"
     KNOWN_PRROTOCOLS = [PROTOCOL_GIT, PROTOCOL_SVN, PROTOCOL_EXTERNALS_ONLY]
 
     # v1 xml keywords
-    _V1_TREE_PATH = 'TREE_PATH'
-    _V1_ROOT = 'ROOT'
-    _V1_TAG = 'TAG'
-    _V1_BRANCH = 'BRANCH'
-    _V1_REQ_SOURCE = 'REQ_SOURCE'
+    _V1_TREE_PATH = "TREE_PATH"
+    _V1_ROOT = "ROOT"
+    _V1_TAG = "TAG"
+    _V1_BRANCH = "BRANCH"
+    _V1_REQ_SOURCE = "REQ_SOURCE"
 
-    _source_schema = {REQUIRED: True,
-                      PATH: 'string',
-                      EXTERNALS: 'string',
-                      SUBMODULE : True,
-                      REPO: {PROTOCOL: 'string',
-                             REPO_URL: 'string',
-                             TAG: 'string',
-                             BRANCH: 'string',
-                             HASH: 'string',
-                             SPARSE: 'string',
-                            }
-                     }
+    _source_schema = {
+        REQUIRED: True,
+        PATH: "string",
+        EXTERNALS: "string",
+        SUBMODULE: True,
+        REPO: {
+            PROTOCOL: "string",
+            REPO_URL: "string",
+            TAG: "string",
+            BRANCH: "string",
+            HASH: "string",
+            SPARSE: "string",
+        },
+    }
 
     def __init__(self, parent_repo=None):
         """Convert the xml into a standardized dict that can be used to
@@ -377,27 +403,25 @@ class ExternalsDescription(dict):
         self._parent_repo = parent_repo
 
     def _verify_schema_version(self):
-        """Use semantic versioning rules to verify we can process this schema.
-
-        """
-        known = '{0}.{1}.{2}'.format(self._schema_major,
-                                     self._schema_minor,
-                                     self._schema_patch)
-        received = '{0}.{1}.{2}'.format(self._input_major,
-                                        self._input_minor,
-                                        self._input_patch)
+        """Use semantic versioning rules to verify we can process this schema."""
+        known = f"{self._schema_major}.{self._schema_minor}.{self._schema_patch}"
+        received = f"{self._input_major}.{self._input_minor}.{self._input_patch}"
 
         if self._input_major != self._schema_major:
             # should never get here, the factory should handle this correctly!
-            msg = ('DEV_ERROR: version "{0}" parser received '
-                   'version "{1}" input.'.format(known, received))
+            msg = (
+                f'DEV_ERROR: version "{known}" parser received '
+                f'version "{received}" input.'
+            )
             fatal_error(msg)
 
         if self._input_minor > self._schema_minor:
-            msg = ('Incompatible schema version:\n'
-                   '  User supplied schema version "{0}" is too new."\n'
-                   '  Can only process version "{1}" files and '
-                   'older.'.format(received, known))
+            msg = (
+                "Incompatible schema version:\n"
+                f'  User supplied schema version "{received}" is too new."\n'
+                f'  Can only process version "{known}" files and '
+                "older."
+            )
             fatal_error(msg)
 
         if self._input_patch > self._schema_patch:
@@ -423,103 +447,118 @@ class ExternalsDescription(dict):
 
     def _check_data(self):
         # pylint: disable=too-many-branches,too-many-statements
-        """Check user supplied data is valid where possible.
-        """
-        for ext_name in self.keys():
-            if (self[ext_name][self.REPO][self.PROTOCOL]
-                    not in self.KNOWN_PRROTOCOLS):
-                msg = 'Unknown repository protocol "{0}" in "{1}".'.format(
-                    self[ext_name][self.REPO][self.PROTOCOL], ext_name)
+        """Check user supplied data is valid where possible."""
+        for ext_name in list(self.keys()):
+            if self[ext_name][self.REPO][self.PROTOCOL] not in self.KNOWN_PRROTOCOLS:
+                msg = (
+                    "Unknown repository protocol "
+                    f'"{self[ext_name][self.REPO][self.PROTOCOL]}" in "{ext_name}".'
+                )
                 fatal_error(msg)
 
-            if (self[ext_name][self.REPO][self.PROTOCOL] ==
-                    self.PROTOCOL_SVN):
+            if self[ext_name][self.REPO][self.PROTOCOL] == self.PROTOCOL_SVN:
                 if self.HASH in self[ext_name][self.REPO]:
-                    msg = ('In repo description for "{0}". svn repositories '
-                           'may not include the "hash" keyword.'.format(
-                               ext_name))
+                    msg = (
+                        f'In repo description for "{ext_name}". svn repositories '
+                        'may not include the "hash" keyword.'
+                    )
                     fatal_error(msg)
 
-            if ((self[ext_name][self.REPO][self.PROTOCOL] != self.PROTOCOL_GIT)
-                    and (self.SUBMODULE in self[ext_name])):
-                msg = ('self.SUBMODULE is only supported with {0} protocol, '
-                       '"{1}" is defined as an {2} repository')
-                fatal_error(msg.format(self.PROTOCOL_GIT, ext_name,
-                                       self[ext_name][self.REPO][self.PROTOCOL]))
+            if (self[ext_name][self.REPO][self.PROTOCOL] != self.PROTOCOL_GIT) and (
+                self.SUBMODULE in self[ext_name]
+            ):
+                msg = (
+                    f"self.SUBMODULE is only supported with {self.PROTOCOL_GIT} protocol, "
+                    f'"{ext_name}" is defined as an '
+                    f"{self[ext_name][self.REPO][self.PROTOCOL]} repository"
+                )
+                fatal_error(msg)
 
-            if (self[ext_name][self.REPO][self.PROTOCOL] !=
-                    self.PROTOCOL_EXTERNALS_ONLY):
+            if self[ext_name][self.REPO][self.PROTOCOL] != self.PROTOCOL_EXTERNALS_ONLY:
                 ref_count = 0
-                found_refs = ''
+                found_refs = ""
                 if self.TAG in self[ext_name][self.REPO]:
                     ref_count += 1
-                    found_refs = '"{0} = {1}", {2}'.format(
-                        self.TAG, self[ext_name][self.REPO][self.TAG],
-                        found_refs)
+                    found_refs = (
+                        f'"{self.TAG} = '
+                        f'"{self[ext_name][self.REPO][self.TAG]}", {found_refs}'
+                    )
                 if self.BRANCH in self[ext_name][self.REPO]:
                     ref_count += 1
-                    found_refs = '"{0} = {1}", {2}'.format(
-                        self.BRANCH, self[ext_name][self.REPO][self.BRANCH],
-                        found_refs)
+                    found_refs = (
+                        f'"{self.BRANCH} = '
+                        '{self[ext_name][self.REPO][self.BRANCH]}", {found_refs}'
+                    )
                 if self.HASH in self[ext_name][self.REPO]:
                     ref_count += 1
-                    found_refs = '"{0} = {1}", {2}'.format(
-                        self.HASH, self[ext_name][self.REPO][self.HASH],
-                        found_refs)
-                if (self.SUBMODULE in self[ext_name] and
-                        self[ext_name][self.SUBMODULE]):
+                    found_refs = (
+                        f'"{self.HASH} = '
+                        '{self[ext_name][self.REPO][self.HASH]}", {found_refs}'
+                    )
+                if self.SUBMODULE in self[ext_name] and self[ext_name][self.SUBMODULE]:
                     ref_count += 1
-                    found_refs = '"{0} = {1}", {2}'.format(
-                        self.SUBMODULE,
-                        self[ext_name][self.SUBMODULE], found_refs)
-
+                    found_refs = (
+                        f'"{self.SUBMODULE} = '
+                        '{self[ext_name][self.SUBMODULE]}", {found_refs}'
+                    )
                 if ref_count > 1:
-                    msg = 'Model description is over specified! '
+                    msg = "Model description is over specified! "
                     if self.SUBMODULE in self[ext_name]:
-                        msg += ('from_submodule is not compatible with '
-                                '"tag", "branch", or "hash" ')
+                        msg += (
+                            "from_submodule is not compatible with "
+                            '"tag", "branch", or "hash" '
+                        )
                     else:
-                        msg += (' Only one of "tag", "branch", or "hash" '
-                                'may be specified ')
+                        msg += (
+                            ' Only one of "tag", "branch", or "hash" '
+                            "may be specified "
+                        )
 
-                    msg += 'for repo description of "{0}".'.format(ext_name)
-                    msg = '{0}\nFound: {1}'.format(msg, found_refs)
+                    msg += f'for repo description of "{ext_name}".'.format(ext_name)
+                    msg += f"\nFound: {found_refs}"
                     fatal_error(msg)
                 elif ref_count < 1:
-                    msg = ('Model description is under specified! One of '
-                           '"tag", "branch", or "hash" must be specified for '
-                           'repo description of "{0}"'.format(ext_name))
+                    msg = (
+                        "Model description is under specified! One of "
+                        '"tag", "branch", or "hash" must be specified for '
+                        f'repo description of "{ext_name}"'
+                    )
                     fatal_error(msg)
 
-                if (self.REPO_URL not in self[ext_name][self.REPO] and
-                        (self.SUBMODULE not in self[ext_name] or
-                         not self[ext_name][self.SUBMODULE])):
-                    msg = ('Model description is under specified! Must have '
-                           '"repo_url" in repo '
-                           'description for "{0}"'.format(ext_name))
+                if self.REPO_URL not in self[ext_name][self.REPO] and (
+                    self.SUBMODULE not in self[ext_name]
+                    or not self[ext_name][self.SUBMODULE]
+                ):
+                    msg = (
+                        "Model description is under specified! Must have "
+                        '"repo_url" in repo '
+                        f'description for "{ext_name}"'
+                    )
                     fatal_error(msg)
 
-                if (self.SUBMODULE in self[ext_name] and
-                        self[ext_name][self.SUBMODULE]):
+                if self.SUBMODULE in self[ext_name] and self[ext_name][self.SUBMODULE]:
                     if self.REPO_URL in self[ext_name][self.REPO]:
-                        msg = ('Model description is over specified! '
-                               'from_submodule keyword is not compatible '
-                               'with {0} keyword for'.format(self.REPO_URL))
-                        msg = '{0} repo description of "{1}"'.format(msg,
-                                                                     ext_name)
+                        msg = (
+                            "Model description is over specified! "
+                            "from_submodule keyword is not compatible "
+                            f"with {self.REPO_URL} keyword for"
+                        )
+                        msg += f' repo description of "{ext_name}"'
                         fatal_error(msg)
 
                     if self.PATH in self[ext_name]:
-                        msg = ('Model description is over specified! '
-                               'from_submodule keyword is not compatible with '
-                               '{0} keyword for'.format(self.PATH))
-                        msg = '{0} repo description of "{1}"'.format(msg,
-                                                                     ext_name)
+                        msg = (
+                            "Model description is over specified! "
+                            "from_submodule keyword is not compatible with "
+                            f"{self.PATH} keyword for"
+                        )
+                        msg += f' repo description of "{ext_name}"'
                         fatal_error(msg)
 
                 if self.REPO_URL in self[ext_name][self.REPO]:
                     url = expand_local_url(
-                        self[ext_name][self.REPO][self.REPO_URL], ext_name)
+                        self[ext_name][self.REPO][self.REPO_URL], ext_name
+                    )
                     self[ext_name][self.REPO][self.REPO_URL] = url
 
     def _check_optional(self):
@@ -531,7 +570,7 @@ class ExternalsDescription(dict):
         default values if appropriate.
 
         """
-        submod_desc = None      # Only load submodules info once
+        submod_desc = None  # Only load submodules info once
         for field in self:
             # truely optional
             if self.EXTERNALS not in self[field]:
@@ -555,21 +594,25 @@ class ExternalsDescription(dict):
                 if self._parent_repo is None:
                     # No parent == no submodule information
                     PPRINTER.pprint(self[field])
-                    msg = 'No parent submodule for "{0}"'.format(field)
+                    msg = f'No parent submodule for "{field}"'
                     fatal_error(msg)
                 elif self._parent_repo.protocol() != self.PROTOCOL_GIT:
                     PPRINTER.pprint(self[field])
-                    msg = 'Parent protocol, "{0}", does not support submodules'
-                    fatal_error(msg.format(self._parent_repo.protocol()))
+                    msg = (
+                        f'Parent protocol, "{self._parent_repo.protocol()}"'
+                        ", does not support submodules"
+                    )
+                    fatal_error(msg)
                 else:
                     args = self._repo_config_from_submodule(field, submod_desc)
                     repo_url, repo_path, ref_hash, submod_desc = args
 
                     if repo_url is None:
-                        msg = ('Cannot checkout "{0}" as a submodule, '
-                               'repo not found in {1} file')
-                        fatal_error(msg.format(field,
-                                               self.GIT_SUBMODULES_FILENAME))
+                        msg = (
+                            f'Cannot checkout "{field}" as a submodule, '
+                            f"repo not found in {self.GIT_SUBMODULES_FILENAME} file"
+                        )
+                        fatal_error(msg)
                     # Fill in submodule fields
                     self[field][self.REPO][self.REPO_URL] = repo_url
                     self[field][self.REPO][self.HASH] = ref_hash
@@ -589,13 +632,14 @@ class ExternalsDescription(dict):
         its submodule configuration information.
         """
         if submod_desc is None:
-            repo_path = os.getcwd() # Is this always correct?
+            repo_path = os.getcwd()  # Is this always correct?
             submod_file = self._parent_repo.submodules_file(repo_path=repo_path)
             if submod_file is None:
-                msg = ('Cannot checkout "{0}" from submodule information\n'
-                       '       Parent repo, "{1}" does not have submodules')
-                fatal_error(msg.format(field, self._parent_repo.name()))
-
+                msg = (
+                    f'Cannot checkout "{field}" from submodule information\n'
+                    f'       Parent repo, "{self._parent_repo.name()}" does not have submodules'
+                )
+                fatal_error(msg)
             submod_file = read_gitmodules_file(repo_path, submod_file)
             submod_desc = create_externals_description(submod_file)
 
@@ -618,25 +662,25 @@ class ExternalsDescription(dict):
         fields.
 
         """
-        def print_compare_difference(data_a, data_b, loc_a, loc_b):
-            """Look through the data structures and print the differences.
 
-            """
+        def print_compare_difference(data_a, data_b, loc_a, loc_b):
+            """Look through the data structures and print the differences."""
             for item in data_a:
                 if item in data_b:
                     if not isinstance(data_b[item], type(data_a[item])):
-                        printlog("    {item}: {loc} = {val} ({val_type})".format(
-                            item=item, loc=loc_a, val=data_a[item],
-                            val_type=type(data_a[item])))
-                        printlog("    {item}  {loc} = {val} ({val_type})".format(
-                            item=' ' * len(item), loc=loc_b, val=data_b[item],
-                            val_type=type(data_b[item])))
+                        printlog(
+                            f"    {item}: {loc_a} = {data_a[item]} ({type(data_a[item])})"
+                        )
+                        whitespace = " " * len(item)
+                        printlog(
+                            f"    {whitespace}  {loc_b} = {data_b[item]} ({type(data_b[item])})"
+                        )
                 else:
-                    printlog("    {item}: {loc} = {val} ({val_type})".format(
-                        item=item, loc=loc_a, val=data_a[item],
-                        val_type=type(data_a[item])))
-                    printlog("    {item}  {loc} missing".format(
-                        item=' ' * len(item), loc=loc_b))
+                    printlog(
+                        f"    {item}: {loc_a} = {data_a[item]} ({type(data_a[item])})"
+                    )
+                    whitespace = " " * len(item)
+                    printlog(f"    {whitespace}  {loc_b} missing")
 
         def validate_data_struct(schema, data):
             """Compare a data structure against a schema and validate all required
@@ -652,8 +696,7 @@ class ExternalsDescription(dict):
                 for key in schema:
                     in_ref = in_ref and (key in data)
                     if in_ref:
-                        valid = valid and (
-                            validate_data_struct(schema[key], data[key]))
+                        valid = valid and (validate_data_struct(schema[key], data[key]))
 
                 is_valid = in_ref and valid
             else:
@@ -664,12 +707,11 @@ class ExternalsDescription(dict):
             if not is_valid:
                 printlog("  Unmatched schema and input:")
                 if isinstance(schema, dict):
-                    print_compare_difference(schema, data, 'schema', 'input')
-                    print_compare_difference(data, schema, 'input', 'schema')
+                    print_compare_difference(schema, data, "schema", "input")
+                    print_compare_difference(data, schema, "input", "schema")
                 else:
-                    printlog("    schema = {0} ({1})".format(
-                        schema, type(schema)))
-                    printlog("    input = {0} ({1})".format(data, type(data)))
+                    printlog(f"    schema = {schema} ({type(schema)})")
+                    printlog(f"    input = {data} ({type(data)})")
 
             return is_valid
 
@@ -678,7 +720,7 @@ class ExternalsDescription(dict):
             if not valid:
                 PPRINTER.pprint(self._source_schema)
                 PPRINTER.pprint(self[field])
-                msg = 'ERROR: source for "{0}" did not validate'.format(field)
+                msg = f'ERROR: source for "{field}" did not validate'
                 fatal_error(msg)
 
 
@@ -690,8 +732,7 @@ class ExternalsDescriptionDict(ExternalsDescription):
     """
 
     def __init__(self, model_data, components=None, exclude=None):
-        """Parse a native dictionary into a externals description.
-        """
+        """Parse a native dictionary into a externals description."""
         ExternalsDescription.__init__(self)
         self._schema_major = 1
         self._schema_minor = 0
@@ -729,8 +770,11 @@ class ExternalsDescriptionConfigV1(ExternalsDescription):
         self._schema_major = 1
         self._schema_minor = 1
         self._schema_patch = 0
-        self._input_major, self._input_minor, self._input_patch = \
-            get_cfg_schema_version(model_data)
+        (
+            self._input_major,
+            self._input_minor,
+            self._input_patch,
+        ) = get_cfg_schema_version(model_data)
         self._verify_schema_version()
         self._remove_metadata(model_data)
         self._parse_cfg(model_data, components=components, exclude=exclude)
@@ -746,11 +790,10 @@ class ExternalsDescriptionConfigV1(ExternalsDescription):
         model_data.remove_section(DESCRIPTION_SECTION)
 
     def _parse_cfg(self, cfg_data, components=None, exclude=None):
-        """Parse a config_parser object into a externals description.
-        """
+        """Parse a config_parser object into a externals description."""
+
         def list_to_dict(input_list, convert_to_lower_case=True):
-            """Convert a list of key-value pairs into a dictionary.
-            """
+            """Convert a list of key-value pairs into a dictionary."""
             output_dict = {}
             for item in input_list:
                 key = item[0].strip()
@@ -776,6 +819,5 @@ class ExternalsDescriptionConfigV1(ExternalsDescription):
                     self[name][self.REPO][item] = self[name][item]
                     del self[name][item]
                 else:
-                    msg = ('Invalid input: "{sect}" contains unknown '
-                           'item "{item}".'.format(sect=name, item=item))
+                    msg = f'Invalid input: "{name}" contains unknown ' f'item "{item}".'
                     fatal_error(msg)

--- a/manic/externals_status.py
+++ b/manic/externals_status.py
@@ -29,19 +29,20 @@ class ExternalStatus(object):
     transactions (e.g. add, remove, rename, untracked files).
 
     """
-    DEFAULT = '-'
-    UNKNOWN = '?'
-    EMPTY = 'e'
-    MODEL_MODIFIED = 's'  # a.k.a. out-of-sync
-    DIRTY = 'M'
 
-    STATUS_OK = ' '
-    STATUS_ERROR = '!'
+    DEFAULT = "-"
+    UNKNOWN = "?"
+    EMPTY = "e"
+    MODEL_MODIFIED = "s"  # a.k.a. out-of-sync
+    DIRTY = "M"
+
+    STATUS_OK = " "
+    STATUS_ERROR = "!"
 
     # source types
-    OPTIONAL = 'o'
-    STANDALONE = 's'
-    MANAGED = ' '
+    OPTIONAL = "o"
+    STANDALONE = "s"
+    MANAGED = " "
 
     def __init__(self):
         self.sync_state = self.DEFAULT
@@ -53,8 +54,7 @@ class ExternalStatus(object):
         self.status_output = EMPTY_STR
 
     def log_status_message(self, verbosity):
-        """Write status message to the screen and log file
-        """
+        """Write status message to the screen and log file"""
         self._default_status_message()
         if verbosity >= VERBOSITY_VERBOSE:
             self._verbose_status_message()
@@ -62,32 +62,26 @@ class ExternalStatus(object):
             self._dump_status_message()
 
     def _default_status_message(self):
-        """Return the default terse status message string
-        """
-        msg = '{sync}{clean}{src_type} {path}'.format(
-            sync=self.sync_state, clean=self.clean_state,
-            src_type=self.source_type, path=self.path)
+        """Return the default terse status message string"""
+        msg = f"{self.sync_state}{self.clean_state}{self.source_type} {self.path}"
         printlog(msg)
 
     def _verbose_status_message(self):
-        """Return the verbose status message string
-        """
+        """Return the verbose status message string"""
         clean_str = self.DEFAULT
         if self.clean_state == self.STATUS_OK:
-            clean_str = 'clean sandbox'
+            clean_str = "clean sandbox"
         elif self.clean_state == self.DIRTY:
-            clean_str = 'modified sandbox'
+            clean_str = "modified sandbox"
 
-        sync_str = 'on {0}'.format(self.current_version)
+        sync_str = f"on {0}".format(self.current_version)
         if self.sync_state != self.STATUS_OK:
-            sync_str = '{current} --> {expected}'.format(
-                current=self.current_version, expected=self.expected_version)
-        msg = '        {clean}, {sync}'.format(clean=clean_str, sync=sync_str)
+            sync_str = f"{self.current_version} --> {self.expected_version}"
+        msg = f"        {clean_str}, {sync_str}"
         printlog(msg)
 
     def _dump_status_message(self):
-        """Return the dump status message string
-        """
+        """Return the dump status message string"""
         msg = indent_string(self.status_output, 12)
         printlog(msg)
 
@@ -109,8 +103,10 @@ class ExternalStatus(object):
             # sync_state. Any other sync_state at this point
             # represents a logic error that should have been handled
             # before now!
-            sync_safe = ((self.sync_state == ExternalStatus.STATUS_OK) or
-                         (self.sync_state == ExternalStatus.MODEL_MODIFIED))
+            sync_safe = self.sync_state in (
+                ExternalStatus.STATUS_OK,
+                ExternalStatus.MODEL_MODIFIED,
+            )
             if sync_safe:
                 # The clean_state must be STATUS_OK to update. Otherwise we
                 # are dirty or there was a missed error previously.
@@ -134,10 +130,12 @@ class ExternalStatus(object):
         testing is needed.
 
         """
-        is_empty = (self.sync_state == ExternalStatus.EMPTY)
-        clean_valid = ((self.clean_state == ExternalStatus.DEFAULT) or
-                       (self.clean_state == ExternalStatus.EMPTY) or
-                       (self.clean_state == ExternalStatus.UNKNOWN))
+        is_empty = self.sync_state == ExternalStatus.EMPTY
+        clean_valid = self.clean_state in (
+            ExternalStatus.DEFAULT,
+            ExternalStatus.EMPTY,
+            ExternalStatus.UNKNOWN,
+        )
 
         if is_empty and clean_valid:
             exists = False

--- a/manic/global_constants.py
+++ b/manic/global_constants.py
@@ -7,10 +7,10 @@ from __future__ import print_function
 
 import pprint
 
-EMPTY_STR = ''
-LOCAL_PATH_INDICATOR = '.'
-VERSION_SEPERATOR = '.'
-LOG_FILE_NAME = 'manage_externals.log'
+EMPTY_STR = ""
+LOCAL_PATH_INDICATOR = "."
+VERSION_SEPERATOR = "."
+LOG_FILE_NAME = "manage_externals.log"
 PPRINTER = pprint.PrettyPrinter(indent=4)
 
 VERBOSITY_DEFAULT = 0

--- a/manic/repository.py
+++ b/manic/repository.py
@@ -24,11 +24,14 @@ class Repository(object):
         self._sparse = repo[ExternalsDescription.SPARSE]
 
         if self._url is EMPTY_STR:
-            fatal_error('repo must have a URL')
+            fatal_error("repo must have a URL")
 
-        if ((self._tag is EMPTY_STR) and (self._branch is EMPTY_STR) and
-                (self._hash is EMPTY_STR)):
-            fatal_error('{0} repo must have a branch, tag or hash element')
+        if (
+            (self._tag is EMPTY_STR)
+            and (self._branch is EMPTY_STR)
+            and (self._hash is EMPTY_STR)
+        ):
+            fatal_error("{0} repo must have a branch, tag or hash element")
 
         ref_count = 0
         if self._tag is not EMPTY_STR:
@@ -38,10 +41,13 @@ class Repository(object):
         if self._hash is not EMPTY_STR:
             ref_count += 1
         if ref_count != 1:
-            fatal_error('repo {0} must have exactly one of '
-                        'tag, branch or hash.'.format(self._name))
+            fatal_error(
+                f"repo {self._name} must have exactly one of " "tag, branch or hash."
+            )
 
-    def checkout(self, base_dir_path, repo_dir_name, verbosity, recursive):  # pylint: disable=unused-argument
+    def checkout(
+        self, base_dir_path, repo_dir_name, verbosity, recursive
+    ):  # pylint: disable=unused-argument
         """
         If the repo destination directory exists, ensure it is correct (from
         correct URL, correct branch or tag), and possibly update the source.
@@ -50,16 +56,20 @@ class Repository(object):
         NB: <recursive> is include as an argument for compatibility with
             git functionality (repository_git.py)
         """
-        msg = ('DEV_ERROR: checkout method must be implemented in all '
-               'repository classes! {0}'.format(self.__class__.__name__))
+        msg = (
+            "DEV_ERROR: checkout method must be implemented in all "
+            f"repository classes! {self.__class__.__name__}"
+        )
+
         fatal_error(msg)
 
     def status(self, stat, repo_dir_path):  # pylint: disable=unused-argument
-        """Report the status of the repo
+        """Report the status of the repo"""
+        msg = (
+            "DEV_ERROR: status method must be implemented in all "
+            f"repository classes! {self.__class__.__name__}"
+        )
 
-        """
-        msg = ('DEV_ERROR: status method must be implemented in all '
-               'repository classes! {0}'.format(self.__class__.__name__))
         fatal_error(msg)
 
     def submodules_file(self, repo_path=None):
@@ -68,31 +78,25 @@ class Repository(object):
         return None
 
     def url(self):
-        """Public access of repo url.
-        """
+        """Public access of repo url."""
         return self._url
 
     def tag(self):
-        """Public access of repo tag
-        """
+        """Public access of repo tag"""
         return self._tag
 
     def branch(self):
-        """Public access of repo branch.
-        """
+        """Public access of repo branch."""
         return self._branch
 
     def hash(self):
-        """Public access of repo hash.
-        """
+        """Public access of repo hash."""
         return self._hash
 
     def name(self):
-        """Public access of repo name.
-        """
+        """Public access of repo name."""
         return self._name
 
     def protocol(self):
-        """Public access of repo protocol.
-        """
+        """Public access of repo protocol."""
         return self._protocol

--- a/manic/repository_factory.py
+++ b/manic/repository_factory.py
@@ -17,13 +17,15 @@ def create_repository(component_name, repo_info, svn_ignore_ancestry=False):
 
     """
     protocol = repo_info[ExternalsDescription.PROTOCOL].lower()
-    if protocol == 'git':
+    if protocol == "git":
         repo = GitRepository(component_name, repo_info)
-    elif protocol == 'svn':
-        repo = SvnRepository(component_name, repo_info, ignore_ancestry=svn_ignore_ancestry)
-    elif protocol == 'externals_only':
+    elif protocol == "svn":
+        repo = SvnRepository(
+            component_name, repo_info, ignore_ancestry=svn_ignore_ancestry
+        )
+    elif protocol == "externals_only":
         repo = None
     else:
-        msg = 'Unknown repo protocol "{0}"'.format(protocol)
+        msg = f'Unknown repo protocol "{protocol}"'
         fatal_error(msg)
     return repo

--- a/manic/utils.py
+++ b/manic/utils.py
@@ -3,11 +3,6 @@
 Common public utilities for manic package
 
 """
-
-from __future__ import absolute_import
-from __future__ import unicode_literals
-from __future__ import print_function
-
 import logging
 import os
 import subprocess
@@ -30,7 +25,7 @@ def log_process_output(output):
     line. This makes it hard to filter with grep.
 
     """
-    output = output.split('\n')
+    output = output.split("\n")
     for line in output:
         logging.debug(line)
 
@@ -68,9 +63,9 @@ def last_n_lines(the_string, n_lines, truncation_message=None):
         return_val = the_string
     else:
         lines_subset = lines[-n_lines:]
-        str_truncated = ''.join(lines_subset)
+        str_truncated = "".join(lines_subset)
         if truncation_message:
-            str_truncated = truncation_message + '\n' + str_truncated
+            str_truncated = truncation_message + "\n" + str_truncated
         return_val = str_truncated
 
     return return_val
@@ -90,9 +85,10 @@ def indent_string(the_string, indent_level):
     """
 
     lines = the_string.splitlines(True)
-    padding = ' ' * indent_level
+    padding = " " * indent_level
     lines_indented = [padding + line for line in lines]
-    return ''.join(lines_indented)
+    return "".join(lines_indented)
+
 
 # ---------------------------------------------------------------------
 #
@@ -106,7 +102,7 @@ def fatal_error(message):
     Error output function
     """
     logging.error(message)
-    raise RuntimeError("{0}ERROR: {1}".format(os.linesep, message))
+    raise RuntimeError(f"{os.linesep}ERROR: {message}")
 
 
 # ---------------------------------------------------------------------
@@ -121,24 +117,26 @@ def str_to_bool(bool_str):
     """
     value = None
     str_lower = bool_str.lower()
-    if str_lower in ('true', 't'):
+    if str_lower in ("true", "t"):
         value = True
-    elif str_lower in ('false', 'f'):
+    elif str_lower in ("false", "f"):
         value = False
     if value is None:
-        msg = ('ERROR: invalid boolean string value "{0}". '
-               'Must be "true" or "false"'.format(bool_str))
+        msg = (
+            f'ERROR: invalid boolean string value "{bool_str}". '
+            'Must be "true" or "false"'
+        )
         fatal_error(msg)
     return value
 
 
-REMOTE_PREFIXES = ['http://', 'https://', 'ssh://', 'git@']
+REMOTE_PREFIXES = ["http://", "https://", "ssh://", "git@"]
 
 
 def is_remote_url(url):
     """check if the user provided a local file path instead of a
-       remote. If so, it must be expanded to an absolute
-       path.
+    remote. If so, it must be expanded to an absolute
+    path.
 
     """
     remote_url = False
@@ -150,7 +148,7 @@ def is_remote_url(url):
 
 def split_remote_url(url):
     """check if the user provided a local file path or a
-       remote. If remote, try to strip off protocol info.
+    remote. If remote, try to strip off protocol info.
 
     """
     remote_url = is_remote_url(url)
@@ -158,13 +156,13 @@ def split_remote_url(url):
         return url
 
     for prefix in REMOTE_PREFIXES:
-        url = url.replace(prefix, '')
+        url = url.replace(prefix, "")
 
-    if '@' in url:
-        url = url.split('@')[1]
+    if "@" in url:
+        url = url.split("@")[1]
 
-    if ':' in url:
-        url = url.split(':')[1]
+    if ":" in url:
+        url = url.split(":")[1]
 
     return url
 
@@ -186,10 +184,12 @@ def expand_local_url(url, field):
             url = os.path.expandvars(url)
             url = os.path.expanduser(url)
             if not os.path.isabs(url):
-                msg = ('WARNING: Externals description for "{0}" contains a '
-                       'url that is not remote and does not expand to an '
-                       'absolute path. Version control operations may '
-                       'fail.\n\nurl={1}'.format(field, url))
+                msg = (
+                    f'WARNING: Externals description for "{field}" contains a '
+                    "url that is not remote and does not expand to an "
+                    "absolute path. Version control operations may "
+                    f"fail.\n\nurl={url}"
+                )
                 printlog(msg)
             else:
                 url = os.path.normpath(url)
@@ -208,11 +208,12 @@ _HANGING_SEC = 300
 
 
 def _hanging_msg(working_directory, command):
-    print("""
+    print(
+        f"""
 
 Command '{command}'
 from directory {working_directory}
-has taken {hanging_sec} seconds. It may be hanging.
+has taken {_HANGING_SEC} seconds. It may be hanging.
 
 The command will continue to run, but you may want to abort
 manage_externals with ^C and investigate. A possible cause of hangs is
@@ -222,13 +223,11 @@ information will not be displayed to the user. In this case, the program
 will appear to hang. Ensure you can run svn and git manually and access
 all repositories without entering your authentication information.
 
-""".format(command=command,
-           working_directory=working_directory,
-           hanging_sec=_HANGING_SEC))
+"""
+    )
 
 
-def execute_subprocess(commands, status_to_caller=False,
-                       output_to_caller=False):
+def execute_subprocess(commands, status_to_caller=False, output_to_caller=False):
     """Wrapper around subprocess.check_output to handle common
     exceptions.
 
@@ -242,32 +241,35 @@ def execute_subprocess(commands, status_to_caller=False,
 
     """
     cwd = os.getcwd()
-    msg = 'In directory: {0}\nexecute_subprocess running command:'.format(cwd)
+    msg = f"In directory: {cwd}\nexecute_subprocess running command:"
     logging.info(msg)
-    commands_str = ' '.join(commands)
+    commands_str = " ".join(commands)
     logging.info(commands_str)
     return_to_caller = status_to_caller or output_to_caller
     status = -1
-    output = ''
-    hanging_timer = Timer(_HANGING_SEC, _hanging_msg,
-                          kwargs={"working_directory": cwd,
-                                  "command": commands_str})
+    output = ""
+    hanging_timer = Timer(
+        _HANGING_SEC,
+        _hanging_msg,
+        kwargs={"working_directory": cwd, "command": commands_str},
+    )
     hanging_timer.start()
     try:
-        output = subprocess.check_output(commands, stderr=subprocess.STDOUT,
-                                         universal_newlines=True)
+        output = subprocess.check_output(
+            commands, stderr=subprocess.STDOUT, universal_newlines=True
+        )
         log_process_output(output)
         status = 0
     except OSError as error:
         msg = failed_command_msg(
-            'Command execution failed. Does the executable exist?',
-            commands)
+            "Command execution failed. Does the executable exist?", commands
+        )
         logging.error(error)
         fatal_error(msg)
     except ValueError as error:
         msg = failed_command_msg(
-            'DEV_ERROR: Invalid arguments trying to run subprocess',
-            commands)
+            "DEV_ERROR: Invalid arguments trying to run subprocess", commands
+        )
         logging.error(error)
         fatal_error(msg)
     except subprocess.CalledProcessError as error:
@@ -277,10 +279,11 @@ def execute_subprocess(commands, status_to_caller=False,
         # responsibility determine if an error occurred and handle it
         # appropriately.
         if not return_to_caller:
-            msg_context = ('Process did not run successfully; '
-                           'returned status {0}'.format(error.returncode))
-            msg = failed_command_msg(msg_context, commands,
-                                     output=error.output)
+            msg_context = (
+                "Process did not run successfully; "
+                f"returned status {error.returncode}"
+            )
+            msg = failed_command_msg(msg_context, commands, output=error.output)
             logging.error(error)
             logging.error(msg)
             log_process_output(error.output)
@@ -309,22 +312,22 @@ def failed_command_msg(msg_context, command, output=None):
     """
 
     if output:
-        output_truncated = last_n_lines(output, 20,
-                                        truncation_message='[... Output truncated for brevity ...]')
-        errmsg = ('Failed with output:\n' +
-                  indent_string(output_truncated, 4) +
-                  '\nERROR: ')
+        output_truncated = last_n_lines(
+            output, 20, truncation_message="[... Output truncated for brevity ...]"
+        )
+        errmsg = (
+            "Failed with output:\n" + indent_string(output_truncated, 4) + "\nERROR: "
+        )
     else:
-        errmsg = ''
+        errmsg = ""
 
-    command_str = ' '.join(command)
-    errmsg += """In directory
-    {cwd}
-{context}:
-    {command}
-""".format(cwd=os.getcwd(), context=msg_context, command=command_str)
-
+    command_str = " ".join(command)
+    errmsg += f"""In directory
+    {os.getcwd()}
+{msg_context}:
+    {command_str}
+"""
     if output:
-        errmsg += 'See above for output from failed command.\n'
+        errmsg += "See above for output from failed command.\n"
 
     return errmsg

--- a/test/test_sys_checkout.py
+++ b/test/test_sys_checkout.py
@@ -29,11 +29,6 @@ setUpModule.
 # temporary directory be preserved....
 # pylint: disable=too-many-lines
 
-
-from __future__ import absolute_import
-from __future__ import unicode_literals
-from __future__ import print_function
-
 import logging
 import os
 import os.path
@@ -210,14 +205,14 @@ class GenerateExternalsDescriptionCfgV1(object):
         """
         # Create a file for a sparse pattern match
         sparse_filename = 'sparse_checkout'
-        with open(os.path.join(dest_dir, sparse_filename), 'w') as sfile:
+        with open(os.path.join(dest_dir, sparse_filename), 'w', encoding="utf-8") as sfile:
             sfile.write('readme.txt')
 
         self.create_config()
         self.create_section(SIMPLE_REPO_NAME, 'simp_tag',
                             tag='tag2')
 
-        sparse_relpath = '../../{}'.format(sparse_filename)
+        sparse_relpath = f'../../{sparse_filename}'
         self.create_section(SIMPLE_REPO_NAME, 'simp_sparse',
                             tag='tag2', sparse=sparse_relpath)
 
@@ -259,7 +254,7 @@ class GenerateExternalsDescriptionCfgV1(object):
 
         """
         dest_path = os.path.join(dest_dir, filename)
-        with open(dest_path, 'w') as configfile:
+        with open(dest_path, 'w', encoding="utf-8") as configfile:
             self._config.write(configfile)
 
     def create_config(self):
@@ -303,7 +298,7 @@ class GenerateExternalsDescriptionCfgV1(object):
                 ((repo_path is not None) or tag or ref_hash or branch)):
             printlog('create_section: "from_submodule" is incompatible with '
                      '"repo_url", "tag", "hash", and "branch" options;\n'
-                     'Ignoring those options for {}'.format(name))
+                     f'Ignoring those options for {name}')
             repo_url = None
             tag = ''
             ref_hash = ''
@@ -391,8 +386,8 @@ class GenerateExternalsDescriptionCfgV1(object):
         cmd = ['git', 'checkout', '-b', branch, ]
         execute_subprocess(cmd)
         if with_commit:
-            msg = 'start work on {0}'.format(branch)
-            with open(README_NAME, 'a') as handle:
+            msg = f'start work on {branch}'
+            with open(README_NAME, 'a', encoding="utf-8") as handle:
                 handle.write(msg)
             cmd = ['git', 'add', README_NAME, ]
             execute_subprocess(cmd)
@@ -417,7 +412,7 @@ class GenerateExternalsDescriptionCfgV1(object):
             execute_subprocess(cmd)
 
         msg = 'work on great new feature!'
-        with open(README_NAME, 'a') as handle:
+        with open(README_NAME, 'a', encoding="utf-8") as handle:
             handle.write(msg)
         cmd = ['git', 'add', README_NAME, ]
         execute_subprocess(cmd)
@@ -602,7 +597,7 @@ class BaseTestSysCheckout(unittest.TestCase):
         """
         # unique repo for this test
         test_dir_name = self._test_id
-        print("Test repository name: {0}".format(test_dir_name))
+        print(f"Test repository name: {test_dir_name}")
 
         parent_repo_dir = os.path.join(self._bare_root, parent_repo_name)
         if dest_dir_in is None:
@@ -622,7 +617,7 @@ class BaseTestSysCheckout(unittest.TestCase):
         """
         cwd = os.getcwd()
         os.chdir(under_test_dir)
-        with open(filename, 'w') as tmp:
+        with open(filename, 'w', encoding="utf-8") as tmp:
             tmp.write('Hello, world!')
 
         if tracked:
@@ -652,11 +647,9 @@ class BaseTestSysCheckout(unittest.TestCase):
         os.chdir(under_test_dir)
         cmdline = ['--externals', CFG_NAME, ]
         cmdline += args
-        repo_root = 'MANIC_TEST_BARE_REPO_ROOT={root}'.format(
-            root=os.environ[MANIC_TEST_BARE_REPO_ROOT])
-        manual_cmd = ('Test cmd:\npushd {cwd}; {env} {checkout} {args}'.format(
-            cwd=under_test_dir, env=repo_root, checkout=checkout_path,
-            args=' '.join(cmdline)))
+        repo_root = f'MANIC_TEST_BARE_REPO_ROOT={os.environ[MANIC_TEST_BARE_REPO_ROOT]}'
+        args = ' '.join(cmdline)
+        manual_cmd = f'Test cmd:\npushd {under_test_dir}; {repo_root} {checkout_path} {args}'
         printlog(manual_cmd)
         options = checkout.commandline_arguments(cmdline)
         overall_status, tree_status = checkout.main(options)
@@ -704,97 +697,97 @@ class BaseTestSysCheckout(unittest.TestCase):
     #
     # ----------------------------------------------------------------
     def _check_simple_tag_empty(self, tree, directory=EXTERNALS_NAME):
-        name = './{0}/simp_tag'.format(directory)
+        name = f'./{directory}/simp_tag'
         self._check_generic_empty_default_required(tree, name)
 
     def _check_nested_tag_empty(self, tree, name=EXTERNALS_NAME):
         self._check_generic_empty_default_required(tree, name)
 
     def _check_simple_tag_ok(self, tree, directory=EXTERNALS_NAME):
-        name = './{0}/simp_tag'.format(directory)
+        name = f'./{directory}/simp_tag'
         self._check_generic_ok_clean_required(tree, name)
 
     def _check_nested_tag_ok(self, tree, name=EXTERNALS_NAME):
         self._check_generic_ok_clean_required(tree, name)
 
     def _check_simple_tag_dirty(self, tree, directory=EXTERNALS_NAME):
-        name = './{0}/simp_tag'.format(directory)
+        name = f'./{directory}/simp_tag'
         self._check_generic_ok_dirty_required(tree, name)
 
     def _check_simple_tag_modified(self, tree, directory=EXTERNALS_NAME):
-        name = './{0}/simp_tag'.format(directory)
+        name = f'./{directory}/simp_tag'
         self._check_generic_modified_ok_required(tree, name)
 
     def _check_simple_branch_empty(self, tree, directory=EXTERNALS_NAME):
-        name = './{0}/simp_branch'.format(directory)
+        name = f'./{directory}/simp_branch'
         self._check_generic_empty_default_required(tree, name)
 
     def _check_nested_branch_empty(self, tree, name=EXTERNALS_NAME):
         self._check_generic_empty_default_required(tree, name)
 
     def _check_simple_branch_ok(self, tree, directory=EXTERNALS_NAME):
-        name = './{0}/simp_branch'.format(directory)
+        name = f'./{directory}/simp_branch'
         self._check_generic_ok_clean_required(tree, name)
 
     def _check_nested_branch_ok(self, tree, name=EXTERNALS_NAME):
         self._check_generic_ok_clean_required(tree, name)
 
     def _check_simple_branch_modified(self, tree, directory=EXTERNALS_NAME):
-        name = './{0}/simp_branch'.format(directory)
+        name = f'./{directory}/simp_branch'
         self._check_generic_modified_ok_required(tree, name)
 
     def _check_simple_hash_empty(self, tree, directory=EXTERNALS_NAME):
-        name = './{0}/simp_hash'.format(directory)
+        name = f'./{directory}/simp_hash'
         self._check_generic_empty_default_required(tree, name)
 
     def _check_nested_hash_empty(self, tree, name=EXTERNALS_NAME):
         self._check_generic_empty_default_required(tree, name)
 
     def _check_simple_hash_ok(self, tree, directory=EXTERNALS_NAME):
-        name = './{0}/simp_hash'.format(directory)
+        name = f'./{directory}/simp_hash'
         self._check_generic_ok_clean_required(tree, name)
 
     def _check_nested_hash_ok(self, tree, name=EXTERNALS_NAME):
         self._check_generic_ok_clean_required(tree, name)
 
     def _check_simple_hash_modified(self, tree, directory=EXTERNALS_NAME):
-        name = './{0}/simp_hash'.format(directory)
+        name = f'./{directory}/simp_hash'
         self._check_generic_modified_ok_required(tree, name)
 
     def _check_simple_req_empty(self, tree, directory=EXTERNALS_NAME):
-        name = './{0}/simp_req'.format(directory)
+        name = f'./{directory}/simp_req'
         self._check_generic_empty_default_required(tree, name)
 
     def _check_simple_req_ok(self, tree, directory=EXTERNALS_NAME):
-        name = './{0}/simp_req'.format(directory)
+        name = f'./{directory}/simp_req'
         self._check_generic_ok_clean_required(tree, name)
 
     def _check_simple_opt_empty(self, tree, directory=EXTERNALS_NAME):
-        name = './{0}/simp_opt'.format(directory)
+        name = f'./{directory}/simp_opt'
         self._check_generic_empty_default_optional(tree, name)
 
     def _check_simple_opt_ok(self, tree, directory=EXTERNALS_NAME):
-        name = './{0}/simp_opt'.format(directory)
+        name = f'./{directory}/simp_opt'
         self._check_generic_ok_clean_optional(tree, name)
 
     def _check_mixed_ext_branch_empty(self, tree, directory=EXTERNALS_NAME):
-        name = './{0}/mixed_req'.format(directory)
+        name = f'./{directory}/mixed_req'
         self._check_generic_empty_default_required(tree, name)
 
     def _check_mixed_ext_branch_ok(self, tree, directory=EXTERNALS_NAME):
-        name = './{0}/mixed_req'.format(directory)
+        name = f'./{directory}/mixed_req'
         self._check_generic_ok_clean_required(tree, name)
 
     def _check_mixed_ext_branch_modified(self, tree, directory=EXTERNALS_NAME):
-        name = './{0}/mixed_req'.format(directory)
+        name = f'./{directory}/mixed_req'
         self._check_generic_modified_ok_required(tree, name)
 
     def _check_simple_sparse_empty(self, tree, directory=EXTERNALS_NAME):
-        name = './{0}/simp_sparse'.format(directory)
+        name = f'./{directory}/simp_sparse'
         self._check_generic_empty_default_required(tree, name)
 
     def _check_simple_sparse_ok(self, tree, directory=EXTERNALS_NAME):
-        name = './{0}/simp_sparse'.format(directory)
+        name = f'./{directory}/simp_sparse'
         self._check_generic_ok_clean_required(tree, name)
 
     # ----------------------------------------------------------------
@@ -936,8 +929,7 @@ class BaseTestSysCheckout(unittest.TestCase):
         # Note, this is the internal tree status just before checkout
         self.assertEqual(overall, 0)
         self._check_mixed_ext_branch_ok(tree, directory=EXTERNALS_NAME)
-        check_dir = "{0}/{1}/{2}".format(EXTERNALS_NAME, "mixed_req",
-                                         SUB_EXTERNALS_PATH)
+        check_dir = f"{EXTERNALS_NAME}/mixed_req/{SUB_EXTERNALS_PATH}"
         self._check_simple_branch_ok(tree, directory=check_dir)
 
     def _check_mixed_ext_branch_required_pre_checkout_ext_change(
@@ -946,8 +938,7 @@ class BaseTestSysCheckout(unittest.TestCase):
         # externals description file, but before checkout
         self.assertEqual(overall, 0)
         self._check_mixed_ext_branch_modified(tree, directory=EXTERNALS_NAME)
-        check_dir = "{0}/{1}/{2}".format(EXTERNALS_NAME, "mixed_req",
-                                         SUB_EXTERNALS_PATH)
+        check_dir = f"{EXTERNALS_NAME}/mixed_req/{SUB_EXTERNALS_PATH}"
         self._check_simple_branch_ok(tree, directory=check_dir)
 
     def _check_mixed_ext_branch_required_post_checkout_subext_modified(
@@ -956,8 +947,7 @@ class BaseTestSysCheckout(unittest.TestCase):
         # externals description file, but before checkout
         self.assertEqual(overall, 0)
         self._check_mixed_ext_branch_ok(tree, directory=EXTERNALS_NAME)
-        check_dir = "{0}/{1}/{2}".format(EXTERNALS_NAME, "mixed_req",
-                                         SUB_EXTERNALS_PATH)
+        check_dir = f"{EXTERNALS_NAME}/mixed_req/{SUB_EXTERNALS_PATH}"
         self._check_simple_branch_modified(tree, directory=check_dir)
 
     def _check_mixed_cont_simple_required_pre_checkout(self, overall, tree):
@@ -1565,19 +1555,19 @@ class TestSysCheckoutSVN(BaseTestSysCheckout):
     """
 
     def _check_svn_branch_ok(self, tree, directory=EXTERNALS_NAME):
-        name = './{0}/svn_branch'.format(directory)
+        name = f'./{directory}/svn_branch'
         self._check_generic_ok_clean_required(tree, name)
 
     def _check_svn_branch_dirty(self, tree, directory=EXTERNALS_NAME):
-        name = './{0}/svn_branch'.format(directory)
+        name = f'./{directory}/svn_branch'
         self._check_generic_ok_dirty_required(tree, name)
 
     def _check_svn_tag_ok(self, tree, directory=EXTERNALS_NAME):
-        name = './{0}/svn_tag'.format(directory)
+        name = f'./{directory}/svn_tag'
         self._check_generic_ok_clean_required(tree, name)
 
     def _check_svn_tag_modified(self, tree, directory=EXTERNALS_NAME):
-        name = './{0}/svn_tag'.format(directory)
+        name = f'./{directory}/svn_tag'
         self._check_generic_modified_ok_required(tree, name)
 
     def _check_container_simple_svn_post_checkout(self, overall, tree):

--- a/test/test_sys_repository_git.py
+++ b/test/test_sys_repository_git.py
@@ -44,13 +44,13 @@ class GitTestCase(unittest.TestCase):
 
         # Ensure it has a single string
         self.assertEqual(1, len(maybe_hash.split()),
-                         msg="maybe_hash has multiple strings: {}".format(maybe_hash))
+                         msg=f"maybe_hash has multiple strings: {maybe_hash}")
 
         # Ensure that the only characters in the string are ones allowed
         # in hashes
         allowed_chars_set = set('0123456789abcdef')
         self.assertTrue(set(maybe_hash) <= allowed_chars_set,
-                        msg="maybe_hash has non-hash characters: {}".format(maybe_hash))
+                        msg=f"maybe_hash has non-hash characters: {maybe_hash}")
 
 
 class TestGitTestCase(GitTestCase):
@@ -115,7 +115,7 @@ class TestGitRepositoryGitCommands(GitTestCase):
         data = {self._name:
                 {
                     ExternalsDescription.REQUIRED: False,
-                    ExternalsDescription.PATH: 'junk',
+                    ExternalsDescription.PATH: 'git junk',
                     ExternalsDescription.EXTERNALS: '',
                     ExternalsDescription.REPO: rdata,
                 },
@@ -138,7 +138,7 @@ class TestGitRepositoryGitCommands(GitTestCase):
     @staticmethod
     def add_git_commit():
         """Add a git commit in the current directory"""
-        with open('README', 'a') as myfile:
+        with open('README', 'a', encoding="utf-8") as myfile:
             myfile.write('more info')
         execute_subprocess(['git', 'add', 'README'])
         execute_subprocess(['git', 'commit', '-m', 'my commit message'])

--- a/test/test_unit_externals_description.py
+++ b/test/test_unit_externals_description.py
@@ -301,7 +301,7 @@ class TestReadExternalsDescription(unittest.TestCase):
 <source_tree version='1.0.0'>
 invalid file format
 </sourc_tree>"""
-        with open(file_path, 'w') as fhandle:
+        with open(file_path, 'w', encoding="utf-8") as fhandle:
             fhandle.write(contents)
         with self.assertRaises(RuntimeError):
             read_externals_description_file(root_dir, filename)

--- a/test/test_unit_repository_git.py
+++ b/test/test_unit_repository_git.py
@@ -8,10 +8,6 @@ already in the python path.
 """
 # pylint: disable=too-many-lines,protected-access
 
-from __future__ import absolute_import
-from __future__ import unicode_literals
-from __future__ import print_function
-
 import os
 import shutil
 import unittest
@@ -25,12 +21,12 @@ from manic.global_constants import EMPTY_STR
 # NOTE(bja, 2017-11) order is important here. origin should be a
 # subset of other to trap errors on processing remotes!
 GIT_REMOTE_OUTPUT_ORIGIN_UPSTREAM = '''
-upstream	/path/to/other/repo (fetch)
-upstream	/path/to/other/repo (push)
-other	/path/to/local/repo2 (fetch)
-other	/path/to/local/repo2 (push)
-origin	/path/to/local/repo (fetch)
-origin	/path/to/local/repo (push)
+upstream        /path/to/other/repo (fetch)
+upstream        /path/to/other/repo (push)
+other   /path/to/local/repo2 (fetch)
+other   /path/to/local/repo2 (push)
+origin  /path/to/local/repo (fetch)
+origin  /path/to/local/repo (push)
 '''
 
 


### PR DESCRIPTION
[ 50 character, one line summary ]
Do not use lower() on names and paths - these are case specific and so case needs to be preserved.

[ Description of the changes in this commit. It should be enough
  information for someone not following this development to understand. 
  Lines should be wrapped at about 72 characters. ]
Remove lower() function so that case of info in externals file is preserved.   Remove python2 specific code, 
python2 is no longer supported. 


User interface changes?:  No
[ If yes, describe what changed, and steps taken to ensure backward compatibilty ]

Fixes: [Github issue #s] And brief description of each issue.

Testing:
  test removed: none
  unit tests:all pass
  system tests:all pass
  manual testing:

