### PR TITLE
Print full paths to external.cfg files being read

### DIFF
--- a/manic/externals_description.py
+++ b/manic/externals_description.py
@@ -71,7 +71,8 @@ def read_externals_description_file(root_dir, file_name):
     root_dir = os.path.abspath(root_dir)
     msg = 'In directory : {0}'.format(root_dir)
     logging.info(msg)
-    printlog('Processing externals description file : {0}'.format(file_name))
+    printlog('Processing externals description file : {0} ({1})'.format(file_name,
+                                                                        root_dir))
 
     file_path = os.path.join(root_dir, file_name)
     if not os.path.exists(file_name):


### PR DESCRIPTION
[ 50 character, one line summary ]

[ Description of the changes in this commit. It should be enough
  information for someone not following this development to understand. 
  Lines should be wrapped at about 72 characters. ]
Currently we only print the base name, without a directory, which often is the uninformative 'Externals.cfg'

User interface changes?: No
[ If yes, describe what changed, and steps taken to ensure backward compatibilty ]

Fixes: [Github issue #s] And brief description of each issue.

Testing:
  test removed: n/a
  unit tests: n/a
  system tests: n/a
  manual testing: ran manually, saw the additional paths printed.

