### PR TITLE
Further tiny refactorings and docs of checkout API (no-op).

### DIFF
--- a/manic/checkout.py
+++ b/manic/checkout.py
@@ -396,17 +396,17 @@ def main(args):
         load_all = True
 
     root_dir = os.path.abspath(os.getcwd())
-    external_data = read_externals_description_file(root_dir, args.externals)
-    external = create_externals_description(
-        external_data, components=args.components, exclude=args.exclude)
+    model_data = read_externals_description_file(root_dir, args.externals)
+    ext_description = create_externals_description(
+        model_data, components=args.components, exclude=args.exclude)
 
     for comp in args.components:
-        if comp not in external.keys():
+        if comp not in ext_description.keys():
             fatal_error(
                 "No component {} found in {}".format(
                     comp, args.externals))
 
-    source_tree = SourceTree(root_dir, external, svn_ignore_ancestry=args.svn_ignore_ancestry)
+    source_tree = SourceTree(root_dir, ext_description, svn_ignore_ancestry=args.svn_ignore_ancestry)
     if args.components:
         components_str = 'specified components'
     else:


### PR DESCRIPTION
   Remove unused load_all param in _External.checkout().
   Rename _External.checkout_externals() to checkout_subexternals(), to remove the ambiguity about whether the main external pointed to by the _External is itelf checked out (it is not)
   Clarify load_all documentation - it’s always recursive, but applies different criteria at each level.
   Rename variables in checkout.py (e.g. ext_description)  to match the equivalent code in sourcetree.py.

User interface changes?: No

Fixes: follow-on to issue 155, making checkout_externals easier to read/modify.

Testing:
  test removed:
  unit tests:
  system tests:
  manual testing: reran checkout_externals.

