### PR TITLE
Grab bag of test_sys_checkout cleanups

### DIFF
--- a/manic/checkout.py
+++ b/manic/checkout.py
@@ -378,8 +378,8 @@ def main(args):
     the --all option is passed.
 
     Returns a tuple (overall_status, tree_status). overall_status is 0
-    on success, non-zero on failure. tree_status gives the full status
-    if no checkout is happening. If checkout is happening, tree_status
+    on success, non-zero on failure. tree_status is a dict mapping local path
+    to ExternalStatus -- if no checkout is happening. If checkout is happening, tree_status
     is None.
     """
     if args.do_logging:

--- a/test/repos/README.md
+++ b/test/repos/README.md
@@ -7,6 +7,8 @@ git ls-tree --full-tree -r --name-only HEAD
 git cat-file -p HEAD:<filename>
 ```
 
+File contents at a glance:
+```
 container.git/
   readme.txt
 
@@ -28,4 +30,4 @@ mixed-cont-ext.git/
 
 error/
    (no git repo here, just a readme.txt in the clear)
-
+```


### PR DESCRIPTION
*  Doc inside of each test more clearly/consistently.
*  TestSysCheckoutSVN didn’t get the inlining-of-helper-methods treatment, now it has that.
*  Move various standalone repo helper methods (like create_branch) into a RepoUtils class.
*  README.md was missing newlines when rendered as markdown.
*  Doc the return value of checkout.main
*  Remove unused optional method params (e.g. always writing to the same config filename)
*  Fix test_container_exclude_component check - it was looking at the wrong key (which always passes because that key is never present); now it looks for explicit content at the correct key.

User interface changes?: No

Fixes:  none

Testing:
  test removed: none
  unit tests: none
  system tests: 'make stest' passes
  manual testing: none