### PR TITLE
test_sys_checkout - Grab-bag of param renamings. No-op.

### DIFF
--- a/manic/externals_status.py
+++ b/manic/externals_status.py
@@ -30,12 +30,12 @@ class ExternalStatus(object):
 
     """
     # sync_state and clean_state can be one of the following:
-    DEFAULT = '-'  # aka not set yet.
+    DEFAULT = '-'  # not set yet (sync_state).  clean_state can be this if sync_state is EMPTY.
     UNKNOWN = '?'
     EMPTY = 'e'
     MODEL_MODIFIED = 's'  # repo version != externals (sync_state only)
     DIRTY = 'M'       # repo is dirty (clean_state only)
-    STATUS_OK = ' '   # repo is clean/matches externals.
+    STATUS_OK = ' '   # repo is clean (clean_state) or matches externals version (sync_state)
     STATUS_ERROR = '!'
 
     # source_type can be one of the following:


### PR DESCRIPTION
Remove redundant _NAME from repo constants, and consistently add _REPO suffix (This causes the majority of the diffs).

create_branch/commit: Rename dest_dir to local_repo_dir, and repo_name to external_name.
detached head test: doc what 'detached head' is.
write_with_tag: use kwargs because there's a lot of params.  Remove unused defaults.

User interface changes?: No

Fixes: n/a

Testing:
  test removed: n/a
  unit tests: none
  system tests: 'make stest' passes
  manual testing: none

