### PR TITLE
test_sys_checkout: Inline yet another layer of local-path-creation methods (no-op)

### DIFF
--- a/test/repos/README.md
+++ b/test/repos/README.md
@@ -26,7 +26,7 @@ simple-ext-fork.git/
 mixed-cont-ext.git/
   (has branch: new-feature)
   readme.txt
-  sub-externals.cfg (refers to simple-ext.git/ repo)
+  sub-externals.cfg ('simp_branch' section refers to 'feature2' branch in simple-ext.git/ repo)
 
 error/
    (no git repo here, just a readme.txt in the clear)


### PR DESCRIPTION
Also simplify test_container_full, which still had a dedicated/complicated _check companion method, by removing the 3 standard sections that are tested elsewhere. Now it only tests the sub-external path. Moved file-existence checks up to the narrower _bytag test.

User interface changes?: No

Fixes: N/A

Testing:
  test removed: none
  unit tests: none
  system tests: 'make stest' passes
  manual testing: none

