### PR TITLE
Fix incorrect logged path of checkout_externals in test_sys_checkout

### DIFF
--- a/manic/externals_description.py
+++ b/manic/externals_description.py
@@ -88,7 +88,7 @@ def read_externals_description_file(root_dir, file_name):
 
     externals_description = None
     if file_name == ExternalsDescription.GIT_SUBMODULES_FILENAME:
-        externals_description = read_gitmodules_file(root_dir, file_name)
+        externals_description = _read_gitmodules_file(root_dir, file_name)
     else:
         try:
             config = config_parser()
@@ -191,7 +191,7 @@ def parse_submodules_desc_section(section_items, file_path):
 
     return path, url
 
-def read_gitmodules_file(root_dir, file_name):
+def _read_gitmodules_file(root_dir, file_name):
     # pylint: disable=deprecated-method
     # Disabling this check because the method is only used for python2
     # pylint: disable=too-many-locals
@@ -203,12 +203,11 @@ def read_gitmodules_file(root_dir, file_name):
     root_dir = os.path.abspath(root_dir)
     msg = 'In directory : {0}'.format(root_dir)
     logging.info(msg)
-    printlog('Processing submodules description file : {0}'.format(file_name))
 
     file_path = os.path.join(root_dir, file_name)
     if not os.path.exists(file_name):
         msg = ('ERROR: submodules description file, "{0}", does not '
-               'exist at path:\n    {1}'.format(file_name, file_path))
+               'exist in dir:\n    {1}'.format(file_name, root_dir))
         fatal_error(msg)
 
     submodules_description = None
@@ -640,8 +639,11 @@ class ExternalsDescription(dict):
                        '       Parent repo, "{1}" does not have submodules')
                 fatal_error(msg.format(field, self._parent_repo.name()))
 
-            submod_file = read_gitmodules_file(repo_path, submod_file)
-            submod_desc = create_externals_description(submod_file)
+            printlog(
+                'Processing submodules description file : {0} ({1})'.format(
+                    submod_file, repo_path))
+            submod_model_data= _read_gitmodules_file(repo_path, submod_file)
+            submod_desc = create_externals_description(submod_model_data)
 
         # Can we find our external?
         repo_url = None

--- a/test/test_sys_checkout.py
+++ b/test/test_sys_checkout.py
@@ -502,14 +502,16 @@ def _execute_checkout_in_dir(dirname, args, debug_env=''):
     """
     cwd = os.getcwd()
 
-    # Construct a command line for reproducibility; this command is not actually
-    # executed in the test.
-    checkout_path = os.path.abspath('{0}/../../checkout_externals')
+    # Construct a command line for reproducibility; this command is not
+    # actually executed in the test.
     os.chdir(dirname)
     cmdline = ['--externals', CFG_NAME, ]
     cmdline += args
-    manual_cmd = ('Test cmd:\npushd {cwd}; {env} {checkout} {args}'.format(
-        cwd=dirname, checkout=checkout_path, env=debug_env, args=' '.join(cmdline)))
+    manual_cmd = ('Running equivalent of:\n'
+                  'pushd {dirname}; '
+                  '{debug_env} /path/to/checkout_externals {args}'.format(
+                      dirname=dirname, debug_env=debug_env,
+                      args=' '.join(cmdline)))
     printlog(manual_cmd)
     options = checkout.commandline_arguments(cmdline)
     overall_status, tree_status = checkout.main(options)


### PR DESCRIPTION
it was basically the parent of the current directory, which varies throughout the test. (it called abspath with '{0}/../../', which adds arbitrary and not-interpolated subdir '{0}' to the path, then removes it and removes one more level).        

This change dates back to 6 years ago: https://github.com/ESMCI/manage_externals/commit/3009801362ac2337baeba05e1558f037897e3b37

It never mattered since this command line is only for debugging.

User interface changes?:  No

Fixes: none

Testing:
  test removed: none
  unit tests: none
  system tests:  ran an individual test to confirm the printout is now more correct.
  manual testing: none

