### PR TITLE
convert svn access to github to git sparse checkout

### DIFF
--- a/manic/repository_svn.py
+++ b/manic/repository_svn.py
@@ -42,6 +42,9 @@ class SvnRepository(Repository):
         Parse repo (a <repo> XML element).
         """
         Repository.__init__(self, component_name, repo)
+        if 'github.com' in self._url:
+            msg = "SVN access to github.com is no longer supported"
+            fatal_error(msg)
         self._ignore_ancestry = ignore_ancestry
         if self._url.endswith('/'):
             # there is already a '/' separator in the URL; no need to add another

--- a/manic/sourcetree.py
+++ b/manic/sourcetree.py
@@ -293,7 +293,15 @@ class SourceTree(object):
             required = desc[ExternalsDescription.REQUIRED]
             repo_info = desc[ExternalsDescription.REPO]
             subexternals_path = desc[ExternalsDescription.EXTERNALS]
-
+            if repo_info['protocol'] == 'svn' and 'github.com' in repo_info['repo_url']:
+                # change to git sparse checkout
+                repo_info['protocol'] = 'git'
+                if repo_info['repo_url'].endswith('tags/'):
+                    repo_info['repo_url'] =  (repo_info['repo_url'])[:-5]
+                    slash_index = repo_info['tag'].index('/')
+                    repo_info['sparse'] = (repo_info['tag'])[slash_index+1:]
+                    repo_info['tag'] = (repo_info['tag'])[:slash_index]
+                
             repo = create_repository(comp,
                                      repo_info,
                                      svn_ignore_ancestry=svn_ignore_ancestry)


### PR DESCRIPTION
Reinterprets svn access to github.com as a git sparse checkout.

User interface changes?:  Yes
I could not figure out how to maintain the original paths in the checkout so this will require changes in components who have used
svn access to github to do sparse checkout in the past.

Fixes: #203 

Testing:
  test removed:
  unit tests: all pass
  system tests: suprepo tests are failing - this is issue #202 test_container_simple_svn also fails (new)
  manual testing:  Checkout cam using cam6_3_130

